### PR TITLE
Backport localization lock metadata to rel/4.4

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -289,7 +289,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="DoNotStoreStaticTestContextAnalyzerDescription" xml:space="preserve">
     <value>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</value>
-    <comment>{Locked="TestContext"}{Locked="'static'"}</comment>
+    <comment>{Locked=&quot;TestContext&quot;}{Locked=&quot;static&quot;}</comment>
   </data>
   <data name="DoNotStoreStaticTestContextAnalyzerMessageFormat" xml:space="preserve">
     <value>Do not store TestContext in a static member</value>
@@ -301,7 +301,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="PreferAssertFailOverAlwaysFalseConditionsDescription" xml:space="preserve">
     <value>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</value>
-    <comment>{Locked="'Assert.Fail'"}</comment>
+    <comment>{Locked=&quot;Assert.Fail&quot;}</comment>
   </data>
   <data name="PreferAssertFailOverAlwaysFalseConditionsMessageFormat" xml:space="preserve">
     <value>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</value>
@@ -313,7 +313,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="PreferConstructorOverTestInitializeDescription" xml:space="preserve">
     <value>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</value>
-    <comment>{Locked="'readonly'"}{Locked="MSTEST0019"}</comment>
+    <comment>{Locked=&quot;readonly&quot;}{Locked=&quot;MSTEST0019&quot;}</comment>
   </data>
   <data name="PreferConstructorOverTestInitializeMessageFormat" xml:space="preserve">
     <value>Prefer constructors over TestInitialize methods</value>
@@ -325,7 +325,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="PreferDisposeOverTestCleanupDescription" xml:space="preserve">
     <value>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</value>
-    <comment>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</comment>
+    <comment>{Locked=&quot;DisposeAsync&quot;}{Locked=&quot;&apos;Dispose&apos;&quot;}{Locked=&quot;.NET&quot;}{Locked=&quot;MSTEST0022&quot;}</comment>
   </data>
   <data name="PreferDisposeOverTestCleanupMessageFormat" xml:space="preserve">
     <value>Prefer 'Dispose' over TestCleanup methods</value>
@@ -337,7 +337,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="PreferTestCleanupOverDisposeDescription" xml:space="preserve">
     <value>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</value>
-    <comment>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</comment>
+    <comment>{Locked=&quot;[TestCleanup]&quot;}{Locked=&quot;IAsyncDisposable&quot;}{Locked=&quot;MSTEST0021&quot;}</comment>
   </data>
   <data name="PreferTestCleanupOverDisposeMessageFormat" xml:space="preserve">
     <value>Prefer TestCleanup over 'Dispose' methods</value>
@@ -349,7 +349,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="PreferTestInitializeOverConstructorDescription" xml:space="preserve">
     <value>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</value>
-    <comment>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</comment>
+    <comment>{Locked=&quot;[TestInitialize]&quot;}{Locked=&quot;MSTEST0020&quot;}</comment>
   </data>
   <data name="PreferTestInitializeOverConstructorMessageFormat" xml:space="preserve">
     <value>Prefer TestInitialize methods over constructors</value>
@@ -620,7 +620,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="UseDeploymentItemWithTestMethodOrTestClassDescription" xml:space="preserve">
     <value>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</value>
-    <comment>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</comment>
+    <comment>{Locked=&quot;MSTest&quot;}{Locked=&quot;[DeploymentItem]&quot;}</comment>
   </data>
   <data name="UseDeploymentItemWithTestMethodOrTestClassTitle" xml:space="preserve">
     <value>'[DeploymentItem]' can be specified only on test class or test method</value>
@@ -657,7 +657,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="StringAssertToAssertDescription" xml:space="preserve">
     <value>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</value>
-    <comment>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</comment>
+    <comment>{Locked=&quot;StringAssert&quot;}{Locked=&quot;&apos;Assert&apos;&quot;}{Locked=&quot;API&quot;}</comment>
   </data>
   <data name="StringAssertToAssertTitle" xml:space="preserve">
     <value>Use 'Assert' instead of 'StringAssert'</value>
@@ -669,7 +669,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="CollectionAssertToAssertDescription" xml:space="preserve">
     <value>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</value>
-    <comment>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</comment>
+    <comment>{Locked=&quot;CollectionAssert&quot;}{Locked=&quot;&apos;Assert&apos;&quot;}{Locked=&quot;API&quot;}</comment>
   </data>
   <data name="CollectionAssertToAssertTitle" xml:space="preserve">
     <value>Use 'Assert' instead of 'CollectionAssert'</value>
@@ -851,7 +851,7 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="AvoidExplicitDynamicDataSourceTypeDescription" xml:space="preserve">
     <value>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</value>
-    <comment>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</comment>
+    <comment>{Locked=&quot;MSTest 3.8&quot;}{Locked=&quot;DynamicDataSourceType.AutoDetect&quot;}</comment>
   </data>
   <data name="AvoidExplicitDynamicDataSourceTypeTitle" xml:space="preserve">
     <value>Avoid passing an explicit 'DynamicDataSourceType' and use the default auto detect behavior</value>
@@ -1259,6 +1259,6 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="InheritedMemberFromDifferentMSTestVersionDescription" xml:space="preserve">
     <value>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</value>
-    <comment>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</comment>
+    <comment>{Locked=&quot;MSTest&quot;}{Locked=&quot;[TestInitialize]&quot;}{Locked=&quot;[TestCleanup]&quot;}{Locked=&quot;[ClassInitialize]&quot;}{Locked=&quot;[ClassCleanup]&quot;}{Locked=&quot;[TestMethod]&quot;}{Locked=&quot;[DataTestMethod]&quot;}{Locked=&quot;Microsoft.VisualStudio.TestPlatform.TestFramework&quot;}{Locked=&quot;MSTest.TestFramework&quot;}</comment>
   </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -169,8 +169,8 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">Od verze MSTest 3.8 je 'DynamicDataSourceType.AutoDetect' výchozí hodnotou a automaticky rozpoznává vlastnosti, metody a pole, čímž omezuje rozvláčnost a závislost na druhu členu.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">Od verze MSTest 3.8 je 'DynamicDataSourceType.AutoDetect' výchozí hodnotou a automaticky rozpoznává vlastnosti, metody a pole, čímž omezuje rozvláčnost a závislost na druhu členu.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Metody 'CollectionAssert' mají odpovídající protějšky ve třídě 'Assert'. Používání jediného rozhraní API pro kontrolní výrazy zlepšuje konzistenci a usnadňuje vyhledávání.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Metody 'CollectionAssert' mají odpovídající protějšky ve třídě 'Assert'. Používání jediného rozhraní API pro kontrolní výrazy zlepšuje konzistenci a usnadňuje vyhledávání.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">Objekt TestContext předaný inicializaci sestavení nebo třídy je specifický pro daný kontext a při každém spuštění testu se neaktualizuje. Jeho opakované použití ve členovi 'static' může zpřístupnit zastaralý kontext.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">Objekt TestContext předaný inicializaci sestavení nebo třídy je specifický pro daný kontext a při každém spuštění testu se neaktualizuje. Jeho opakované použití ve členovi 'static' může zpřístupnit zastaralý kontext.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest překládá zděděné atributy životního cyklu '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' a '[ClassCleanup]' a testovací atributy '[TestMethod]' a '[DataTestMethod]' podle přesné identity typu architektury. Sestavení architektury bylo přejmenováno z 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', takže základní třída zkompilovaná pro jinou hlavní verzi MSTest zpřístupňuje tyto atributy s jinou identitou typu. Když testovací třída zkompilovaná pro jinou verzi dědí z takové základní třídy, zděděné nastavení a vyčištění se nespustí a zděděné testovací metody se nezjistí, aniž by došlo k chybě sestavení nebo chybě zjišťování. Znovu zkompilujte základní sestavení a u vlastních atributů také sestavení, které atribut definuje, proti stejné verzi MSTest jako testovací projekt.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest překládá zděděné atributy životního cyklu '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' a '[ClassCleanup]' a testovací atributy '[TestMethod]' a '[DataTestMethod]' podle přesné identity typu architektury. Sestavení architektury bylo přejmenováno z 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', takže základní třída zkompilovaná pro jinou hlavní verzi MSTest zpřístupňuje tyto atributy s jinou identitou typu. Když testovací třída zkompilovaná pro jinou verzi dědí z takové základní třídy, zděděné nastavení a vyčištění se nespustí a zděděné testovací metody se nezjistí, aniž by došlo k chybě sestavení nebo chybě zjišťování. Znovu zkompilujte základní sestavení a u vlastních atributů také sestavení, které atribut definuje, proti stejné verzi MSTest jako testovací projekt.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' explicitně vyjadřuje záměrné selhání a umožňuje ve zprávě o selhání zdokumentovat, proč test nemůže pokračovat.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' explicitně vyjadřuje záměrné selhání a umožňuje ve zprávě o selhání zdokumentovat, proč test nemůže pokračovat.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">Konstruktory umožňují inicializaci prostřednictvím polí 'readonly' a poskytují lepší zpětnou vazbu kompilátoru, zejména u typů odkazů s možnou hodnotou null. Toto volitelné pravidlo stylu se vzájemně vylučuje s pravidlem MSTEST0019.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">Konstruktory umožňují inicializaci prostřednictvím polí 'readonly' a poskytují lepší zpětnou vazbu kompilátoru, zejména u typů odkazů s možnou hodnotou null. Toto volitelné pravidlo stylu se vzájemně vylučuje s pravidlem MSTEST0019.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' a 'DisposeAsync' používají standardní vzory životního cyklu .NET, takže je čištění testů konzistentní s produkčním kódem. Toto volitelné pravidlo stylu se vzájemně vylučuje s pravidlem MSTEST0022.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' a 'DisposeAsync' používají standardní vzory životního cyklu .NET, takže je čištění testů konzistentní s produkčním kódem. Toto volitelné pravidlo stylu se vzájemně vylučuje s pravidlem MSTEST0022.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' podporuje asynchronní vyčištění v cílových architekturách, ve kterých není k dispozici 'IAsyncDisposable'. Toto volitelné pravidlo stylu se vzájemně vylučuje s pravidlem MSTEST0021.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' podporuje asynchronní vyčištění v cílových architekturách, ve kterých není k dispozici 'IAsyncDisposable'. Toto volitelné pravidlo stylu se vzájemně vylučuje s pravidlem MSTEST0021.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' podporuje synchronní i asynchronní inicializaci, zatímco u konstruktorů nejde použít await. Toto volitelné pravidlo stylu se vzájemně vylučuje s pravidlem MSTEST0020.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' podporuje synchronní i asynchronní inicializaci, zatímco u konstruktorů nejde použít await. Toto volitelné pravidlo stylu se vzájemně vylučuje s pravidlem MSTEST0020.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Metody 'StringAssert' mají odpovídající protějšky ve třídě 'Assert'. Používání jediného rozhraní 'API' pro kontrolní výrazy zlepšuje konzistenci a usnadňuje vyhledávání.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Metody 'StringAssert' mají odpovídající protějšky ve třídě 'Assert'. Používání jediného rozhraní 'API' pro kontrolní výrazy zlepšuje konzistenci a usnadňuje vyhledávání.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">'MSTest' ignoruje '[DeploymentItem]', pokud se použije mimo testovací třídu nebo testovací metodu.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">'MSTest' ignoruje '[DeploymentItem]', pokud se použije mimo testovací třídu nebo testovací metodu.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -169,8 +169,8 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">Seit MSTest 3.8 ist 'DynamicDataSourceType.AutoDetect' die Standardeinstellung und identifiziert automatisch Eigenschaften, Methoden und Felder, wodurch die Ausführlichkeit und die Kopplung mit der Memberart reduziert werden.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">Seit MSTest 3.8 ist 'DynamicDataSourceType.AutoDetect' die Standardeinstellung und identifiziert automatisch Eigenschaften, Methoden und Felder, wodurch die Ausführlichkeit und die Kopplung mit der Memberart reduziert werden.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'CollectionAssert'-Methoden verfügen über entsprechende 'Assert'-Gegenstücke. Die Verwendung einer Assertions-API verbessert die Konsistenz und Auffindbarkeit.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'CollectionAssert'-Methoden verfügen über entsprechende 'Assert'-Gegenstücke. Die Verwendung einer Assertions-API verbessert die Konsistenz und Auffindbarkeit.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">Der an die Assembly- oder Klasseninitialisierung übergebene TestContext ist spezifisch für diesen Kontext und wird nicht für jede Testausführung aktualisiert. Durch die Wiederverwendung in einem 'static' Member kann veralteter Kontext verfügbar gemacht werden.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">Der an die Assembly- oder Klasseninitialisierung übergebene TestContext ist spezifisch für diesen Kontext und wird nicht für jede Testausführung aktualisiert. Durch die Wiederverwendung in einem 'static' Member kann veralteter Kontext verfügbar gemacht werden.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest löst die geerbten Lebenszyklusattribute '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' und '[ClassCleanup]' sowie die Testattribute '[TestMethod]' und '[DataTestMethod]' anhand ihrer exakten Frameworktypidentität auf. Die Frameworkassembly wurde von 'Microsoft.VisualStudio.TestPlatform.TestFramework' in 'MSTest.TestFramework' umbenannt, sodass eine Basisklasse, die gegen eine andere MSTest-Hauptversion kompiliert wurde, diese Attribute mit einer anderen Typidentität bereitstellt. Wenn eine solche Basisklasse von einer Testklasse geerbt wird, die gegen eine andere Version kompiliert wird, werden die geerbten Setup- und Bereinigungsprozeduren nicht ausgeführt und die geerbten Testmethoden nicht erkannt, ohne dass dabei ein Buildfehler oder ein Ermittlungsfehler auftritt. Kompilieren Sie die Basisassembly und, bei benutzerdefinierten Attributen, die Assembly, die das Attribut definiert, mit derselben MSTest-Version wie das Testprojekt neu.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest löst die geerbten Lebenszyklusattribute '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' und '[ClassCleanup]' sowie die Testattribute '[TestMethod]' und '[DataTestMethod]' anhand ihrer exakten Frameworktypidentität auf. Die Frameworkassembly wurde von 'Microsoft.VisualStudio.TestPlatform.TestFramework' in 'MSTest.TestFramework' umbenannt, sodass eine Basisklasse, die gegen eine andere MSTest-Hauptversion kompiliert wurde, diese Attribute mit einer anderen Typidentität bereitstellt. Wenn eine solche Basisklasse von einer Testklasse geerbt wird, die gegen eine andere Version kompiliert wird, werden die geerbten Setup- und Bereinigungsprozeduren nicht ausgeführt und die geerbten Testmethoden nicht erkannt, ohne dass dabei ein Buildfehler oder ein Ermittlungsfehler auftritt. Kompilieren Sie die Basisassembly und, bei benutzerdefinierten Attributen, die Assembly, die das Attribut definiert, mit derselben MSTest-Version wie das Testprojekt neu.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' macht einen absichtlichen Fehler explizit und ermöglicht es, anhand der Fehlermeldung zu dokumentieren, warum der Test nicht fortgesetzt werden kann.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' macht einen absichtlichen Fehler explizit und ermöglicht es, anhand der Fehlermeldung zu dokumentieren, warum der Test nicht fortgesetzt werden kann.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">Konstruktoren ermöglichen die Initialisierung über 'readonly'-Felder und bieten stärkeres Compilerfeedback, insbesondere bei Verweistypen, die NULL-Werte zulassen. Diese Opt-In-Stilregel und MSTEST0019 schließen sich gegenseitig aus.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">Konstruktoren ermöglichen die Initialisierung über 'readonly'-Felder und bieten stärkeres Compilerfeedback, insbesondere bei Verweistypen, die NULL-Werte zulassen. Diese Opt-In-Stilregel und MSTEST0019 schließen sich gegenseitig aus.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' und 'DisposeAsync' folgen standardmäßigen .NET-Lebensdauermustern, sodass die Testbereinigung mit Produktionscode konsistent ist. Diese Opt-In-Stilregel und MSTEST0022 schließen sich gegenseitig aus.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' und 'DisposeAsync' folgen standardmäßigen .NET-Lebensdauermustern, sodass die Testbereinigung mit Produktionscode konsistent ist. Diese Opt-In-Stilregel und MSTEST0022 schließen sich gegenseitig aus.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' unterstützt die asynchrone Bereinigung für Zielframeworks, in denen 'IAsyncDisposable' nicht verfügbar ist. Diese Opt-In-Stilregel und MSTEST0021 schließen sich gegenseitig aus.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' unterstützt die asynchrone Bereinigung für Zielframeworks, in denen 'IAsyncDisposable' nicht verfügbar ist. Diese Opt-In-Stilregel und MSTEST0021 schließen sich gegenseitig aus.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' unterstützt sowohl die synchrone als auch die asynchrone Initialisierung, auf Konstruktoren kann dagegen nicht gewartet werden. Diese Opt-In-Stilregel und MSTEST0020 schließen sich gegenseitig aus.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' unterstützt sowohl die synchrone als auch die asynchrone Initialisierung, auf Konstruktoren kann dagegen nicht gewartet werden. Diese Opt-In-Stilregel und MSTEST0020 schließen sich gegenseitig aus.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'StringAssert'-Methoden verfügen über entsprechende 'Assert'-Gegenstücke. Die Verwendung einer Assertions-API verbessert die Konsistenz und Auffindbarkeit.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'StringAssert'-Methoden verfügen über entsprechende 'Assert'-Gegenstücke. Die Verwendung einer Assertions-API verbessert die Konsistenz und Auffindbarkeit.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest ignoriert '[DeploymentItem]', wenn es außerhalb einer Testklasse oder Testmethode angewendet wird.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest ignoriert '[DeploymentItem]', wenn es außerhalb einer Testklasse oder Testmethode angewendet wird.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -169,8 +169,8 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">Desde MSTest 3.8, 'DynamicDataSourceType.AutoDetect' es el valor predeterminado e identifica automáticamente propiedades, métodos y campos, lo que reduce el nivel de detalle y el acoplamiento al tipo de miembro.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">Desde MSTest 3.8, 'DynamicDataSourceType.AutoDetect' es el valor predeterminado e identifica automáticamente propiedades, métodos y campos, lo que reduce el nivel de detalle y el acoplamiento al tipo de miembro.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Los métodos 'CollectionAssert' tienen equivalentes 'Assert'. El uso de una API de aserción mejora la coherencia y la detectabilidad.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Los métodos 'CollectionAssert' tienen equivalentes 'Assert'. El uso de una API de aserción mejora la coherencia y la detectabilidad.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">El elemento TestContext pasado a la inicialización de ensamblados o clases es específico de ese contexto y no se actualiza para cada ejecución de prueba. Si se reutiliza en un miembro 'static', se puede exponer un contexto obsoleto.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">El elemento TestContext pasado a la inicialización de ensamblados o clases es específico de ese contexto y no se actualiza para cada ejecución de prueba. Si se reutiliza en un miembro 'static', se puede exponer un contexto obsoleto.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest resuelve los atributos de ciclo de vida heredados "[TestInitialize]", "[TestCleanup]", "[ClassInitialize]" y "[ClassCleanup]", y los atributos de prueba "[TestMethod]" y "[DataTestMethod]", por su identidad de tipo de marco de trabajo exacta. Se cambió el nombre del ensamblado de marco de trabajo de "Microsoft.VisualStudio.TestPlatform.TestFramework" a "MSTest.TestFramework", por lo que una clase base compilada con una principal de MSTest diferente expone estos atributos con una identidad de tipo diferente. Cuando una clase de prueba compilada con otra versión hereda una base de este tipo, la instalación y limpieza heredadas no se ejecutan y no se detectan los métodos de prueba heredados, sin errores de compilación ni de detección. Vuelva a compilar el ensamblado base y, para los atributos personalizados, el ensamblado que define el atributo con la misma versión de MSTest que el proyecto de prueba.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest resuelve los atributos de ciclo de vida heredados "[TestInitialize]", "[TestCleanup]", "[ClassInitialize]" y "[ClassCleanup]", y los atributos de prueba "[TestMethod]" y "[DataTestMethod]", por su identidad de tipo de marco de trabajo exacta. Se cambió el nombre del ensamblado de marco de trabajo de "Microsoft.VisualStudio.TestPlatform.TestFramework" a "MSTest.TestFramework", por lo que una clase base compilada con una principal de MSTest diferente expone estos atributos con una identidad de tipo diferente. Cuando una clase de prueba compilada con otra versión hereda una base de este tipo, la instalación y limpieza heredadas no se ejecutan y no se detectan los métodos de prueba heredados, sin errores de compilación ni de detección. Vuelva a compilar el ensamblado base y, para los atributos personalizados, el ensamblado que define el atributo con la misma versión de MSTest que el proyecto de prueba.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' hace explícito un error intencionado y permite que el mensaje de error documente por qué la prueba no puede continuar.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' hace explícito un error intencionado y permite que el mensaje de error documente por qué la prueba no puede continuar.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">Los constructores permiten la inicialización a través de campos 'readonly' y proporcionan comentarios más seguros del compilador, especialmente con tipos de referencia que admiten un valor NULL. Esta regla de estilo de participación se excluye mutuamente con MSTEST0019.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">Los constructores permiten la inicialización a través de campos 'readonly' y proporcionan comentarios más seguros del compilador, especialmente con tipos de referencia que admiten un valor NULL. Esta regla de estilo de participación se excluye mutuamente con MSTEST0019.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' y 'DisposeAsync' siguen patrones de duración estándar de .NET, lo que hace que la limpieza de pruebas sea coherente con el código de producción. Esta regla de estilo de participación se excluye mutuamente con MSTEST0022.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' y 'DisposeAsync' siguen patrones de duración estándar de .NET, lo que hace que la limpieza de pruebas sea coherente con el código de producción. Esta regla de estilo de participación se excluye mutuamente con MSTEST0022.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' admite la limpieza asincrónica en marcos de destino donde 'IAsyncDisposable' no está disponible. Esta regla de estilo de participación se excluye mutuamente con MSTEST0021.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' admite la limpieza asincrónica en marcos de destino donde 'IAsyncDisposable' no está disponible. Esta regla de estilo de participación se excluye mutuamente con MSTEST0021.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' admite la inicialización sincrónica y asincrónica, mientras que no se pueden esperar constructores. Esta regla de estilo de participación se excluye mutuamente con MSTEST0020.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' admite la inicialización sincrónica y asincrónica, mientras que no se pueden esperar constructores. Esta regla de estilo de participación se excluye mutuamente con MSTEST0020.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Los métodos 'StringAssert' tienen equivalentes 'Assert'. El uso de una API de aserción mejora la coherencia y la detectabilidad.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Los métodos 'StringAssert' tienen equivalentes 'Assert'. El uso de una API de aserción mejora la coherencia y la detectabilidad.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest omite '[DeploymentItem]' cuando se aplica fuera de una clase de prueba o un método de prueba.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest omite '[DeploymentItem]' cuando se aplica fuera de una clase de prueba o un método de prueba.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -169,8 +169,8 @@ Le type doit être une classe
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">Depuis MSTest 3.8, « DynamicDataSourceType.AutoDetect » est la valeur par défaut et identifie automatiquement les propriétés, les méthodes et les champs, ce qui réduit la verbosité et le couplage au type de membre.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">Depuis MSTest 3.8, « DynamicDataSourceType.AutoDetect » est la valeur par défaut et identifie automatiquement les propriétés, les méthodes et les champs, ce qui réduit la verbosité et le couplage au type de membre.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -313,7 +313,7 @@ Le type doit être une classe
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
         <target state="new">'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ Le type doit être une classe
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">Le TestContext transmis à l’initialisation de l’assembly ou de la classe est spécifique à ce contexte et n’est pas mis à jour pour chaque exécution de test. Sa réutilisation dans un membre « static » peut exposer un contexte obsolète.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">Le TestContext transmis à l’initialisation de l’assembly ou de la classe est spécifique à ce contexte et n’est pas mis à jour pour chaque exécution de test. Sa réutilisation dans un membre « static » peut exposer un contexte obsolète.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest résout les attributs de cycle de vie hérités « [TestInitialize] », « [TestCleanup] », « [ClassInitialize] » et « [ClassCleanup] », ainsi que les attributs de test « [TestMethod] » et « [DataTestMethod] », selon l’identité exacte de leur type d’infrastructure. L’assembly d’infrastructure a été renommé de « Microsoft.VisualStudio.TestPlatform.TestFramework » en « MSTest.TestFramework », si bien qu’une classe de base compilée avec une version majeure différente de MSTest expose ces attributs avec une identité de type différente. Lorsqu’une telle classe de base est héritée par une classe de test compilée avec une autre version, la configuration et le nettoyage hérités ne s’exécutent pas et les méthodes de test héritées ne sont pas détectées, sans erreur de compilation ni erreur de découverte. Recompilez l’assembly de base et, pour les attributs personnalisés, l’assembly qui définit l’attribut par rapport à la même version MSTest que le projet de test.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest résout les attributs de cycle de vie hérités « [TestInitialize] », « [TestCleanup] », « [ClassInitialize] » et « [ClassCleanup] », ainsi que les attributs de test « [TestMethod] » et « [DataTestMethod] », selon l’identité exacte de leur type d’infrastructure. L’assembly d’infrastructure a été renommé de « Microsoft.VisualStudio.TestPlatform.TestFramework » en « MSTest.TestFramework », si bien qu’une classe de base compilée avec une version majeure différente de MSTest expose ces attributs avec une identité de type différente. Lorsqu’une telle classe de base est héritée par une classe de test compilée avec une autre version, la configuration et le nettoyage hérités ne s’exécutent pas et les méthodes de test héritées ne sont pas détectées, sans erreur de compilation ni erreur de découverte. Recompilez l’assembly de base et, pour les attributs personnalisés, l’assembly qui définit l’attribut par rapport à la même version MSTest que le projet de test.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ Le type déclarant ces méthodes doit également respecter les règles suivantes
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">« Assert.Fail » rend explicite un échec intentionnel et permet au message d’échec d’expliquer pourquoi le test ne peut pas continuer.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">« Assert.Fail » rend explicite un échec intentionnel et permet au message d’échec d’expliquer pourquoi le test ne peut pas continuer.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ Le type déclarant ces méthodes doit également respecter les règles suivantes
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">Les constructeurs autorisent l’initialisation via des champs « readonly » et fournissent un retour plus explicite du compilateur, en particulier avec les types référence nullables. Cette règle de style en acceptation est mutuellement exclusive avec MSTEST0019.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">Les constructeurs autorisent l’initialisation via des champs « readonly » et fournissent un retour plus explicite du compilateur, en particulier avec les types référence nullables. Cette règle de style en acceptation est mutuellement exclusive avec MSTEST0019.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
         <target state="new">'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">« [TestCleanup] » prend en charge le nettoyage asynchrone sur les frameworks cibles où « IAsyncDisposable » n’est pas disponible. Cette règle de style en acceptation est mutuellement exclusive avec MSTEST0021.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">« [TestCleanup] » prend en charge le nettoyage asynchrone sur les frameworks cibles où « IAsyncDisposable » n’est pas disponible. Cette règle de style en acceptation est mutuellement exclusive avec MSTEST0021.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' prend en charge l’initialisation synchrone et asynchrone, alors que les constructeurs ne peuvent pas être attendus. Cette règle de style en acceptation est mutuellement exclusive avec MSTEST0020.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' prend en charge l’initialisation synchrone et asynchrone, alors que les constructeurs ne peuvent pas être attendus. Cette règle de style en acceptation est mutuellement exclusive avec MSTEST0020.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -958,7 +958,7 @@ Le type déclarant ces méthodes doit également respecter les règles suivantes
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
         <target state="new">'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ Le type doit être une classe
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest ignore « [DeploymentItem] » lorsqu’il est appliqué en dehors d’une classe ou d’une méthode de test.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest ignore « [DeploymentItem] » lorsqu’il est appliqué en dehors d’une classe ou d’une méthode de test.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -169,8 +169,8 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">Da MSTest 3.8, 'DynamicDataSourceType.AutoDetect' è l'impostazione predefinita e identifica automaticamente proprietà, metodi e campi, riducendo la verbosità e il collegamento al tipo di membro.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">Da MSTest 3.8, 'DynamicDataSourceType.AutoDetect' è l'impostazione predefinita e identifica automaticamente proprietà, metodi e campi, riducendo la verbosità e il collegamento al tipo di membro.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">I metodi 'CollectionAssert' hanno controparti equivalenti in 'Assert'. L'uso di una sola API di asserzione migliora la coerenza e la facilità di individuazione.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">I metodi 'CollectionAssert' hanno controparti equivalenti in 'Assert'. L'uso di una sola API di asserzione migliora la coerenza e la facilità di individuazione.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">Il TestContext passato all'inizializzazione dell'assembly o della classe è specifico di quel contesto e non viene aggiornato per ogni esecuzione del test. Il suo riutilizzo in un membro 'static' può esporre un contesto obsoleto.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">Il TestContext passato all'inizializzazione dell'assembly o della classe è specifico di quel contesto e non viene aggiornato per ogni esecuzione del test. Il suo riutilizzo in un membro 'static' può esporre un contesto obsoleto.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest risolve gli attributi del ciclo di vita ereditati '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' e '[ClassCleanup]', e gli attributi di test '[TestMethod]' e '[DataTestMethod]', in base all'identità esatta del tipo del framework. L'assembly del framework è stato rinominato da 'Microsoft.VisualStudio.TestPlatform.TestFramework' in 'MSTest.TestFramework', quindi una classe di base compilata con una versione principale diversa di MSTest espone questi attributi con un'identità di tipo differente. Quando una base di questo tipo viene ereditata da una classe di test compilata con un'altra versione, le operazioni di configurazione e pulizia ereditate non vengono eseguite e i metodi di test ereditati non vengono individuati, senza errori di compilazione né di individuazione. Ricompilare l'assembly di base e, per gli attributi personalizzati, l'assembly che definisce l'attributo usando la stessa versione di MSTest del progetto di test.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest risolve gli attributi del ciclo di vita ereditati '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' e '[ClassCleanup]', e gli attributi di test '[TestMethod]' e '[DataTestMethod]', in base all'identità esatta del tipo del framework. L'assembly del framework è stato rinominato da 'Microsoft.VisualStudio.TestPlatform.TestFramework' in 'MSTest.TestFramework', quindi una classe di base compilata con una versione principale diversa di MSTest espone questi attributi con un'identità di tipo differente. Quando una base di questo tipo viene ereditata da una classe di test compilata con un'altra versione, le operazioni di configurazione e pulizia ereditate non vengono eseguite e i metodi di test ereditati non vengono individuati, senza errori di compilazione né di individuazione. Ricompilare l'assembly di base e, per gli attributi personalizzati, l'assembly che definisce l'attributo usando la stessa versione di MSTest del progetto di test.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' rende esplicito un errore intenzionale e consente al messaggio di errore di documentare il motivo per cui il test non può continuare.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' rende esplicito un errore intenzionale e consente al messaggio di errore di documentare il motivo per cui il test non può continuare.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">I costruttori consentono l'inizializzazione tramite campi 'readonly' e forniscono un feedback del compilatore più efficace, soprattutto con i tipi riferimento che ammettono i valori Null. Questa regola di stile facoltativa è mutuamente esclusiva con MSTEST0019.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">I costruttori consentono l'inizializzazione tramite campi 'readonly' e forniscono un feedback del compilatore più efficace, soprattutto con i tipi riferimento che ammettono i valori Null. Questa regola di stile facoltativa è mutuamente esclusiva con MSTEST0019.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' e 'DisposeAsync' seguono i modelli standard del ciclo di vita .NET, rendendo la pulizia dei test coerente con il codice di produzione. Questa regola di stile facoltativa è mutuamente esclusiva con MSTEST0022.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' e 'DisposeAsync' seguono i modelli standard del ciclo di vita .NET, rendendo la pulizia dei test coerente con il codice di produzione. Questa regola di stile facoltativa è mutuamente esclusiva con MSTEST0022.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' supporta la pulizia asincrona nei framework di destinazione in cui 'IAsyncDisposable' non è disponibile. Questa regola di stile facoltativa è mutuamente esclusiva con MSTEST0021.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' supporta la pulizia asincrona nei framework di destinazione in cui 'IAsyncDisposable' non è disponibile. Questa regola di stile facoltativa è mutuamente esclusiva con MSTEST0021.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' supporta sia l'inizializzazione sincrona sia quella asincrona, mentre i costruttori non possono essere attesi. Questa regola di stile facoltativa è mutuamente esclusiva con MSTEST0020.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' supporta sia l'inizializzazione sincrona sia quella asincrona, mentre i costruttori non possono essere attesi. Questa regola di stile facoltativa è mutuamente esclusiva con MSTEST0020.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">I metodi 'StringAssert' hanno controparti equivalenti in 'Assert'. L'uso di una sola API di asserzione migliora la coerenza e la facilità di individuazione.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">I metodi 'StringAssert' hanno controparti equivalenti in 'Assert'. L'uso di una sola API di asserzione migliora la coerenza e la facilità di individuazione.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest ignora '[DeploymentItem]' quando viene applicato al di fuori di una classe di test o di un metodo di test.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest ignora '[DeploymentItem]' quando viene applicato al di fuori di una classe di test o di un metodo di test.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -169,8 +169,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">MSTest 3.8 以降では、'DynamicDataSourceType.AutoDetect' が既定値であり、プロパティ、メソッド、およびフィールドが自動的に識別されるため、冗長さとメンバーの種類への結合が減少します。</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">MSTest 3.8 以降では、'DynamicDataSourceType.AutoDetect' が既定値であり、プロパティ、メソッド、およびフィールドが自動的に識別されるため、冗長さとメンバーの種類への結合が減少します。</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'CollectionAssert' メソッドには、対応する同等の 'Assert' メソッドがあります。1 つのアサーション API を使用すると、一貫性と見つかりやすさが向上します。</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'CollectionAssert' メソッドには、対応する同等の 'Assert' メソッドがあります。1 つのアサーション API を使用すると、一貫性と見つかりやすさが向上します。</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">アセンブリまたはクラスの初期化に渡される TestContext は、そのコンテキストに固有であり、テストの実行ごとに更新されません。'static' メンバーで再利用すると、古いコンテキストが公開される可能性があります。</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">アセンブリまたはクラスの初期化に渡される TestContext は、そのコンテキストに固有であり、テストの実行ごとに更新されません。'static' メンバーで再利用すると、古いコンテキストが公開される可能性があります。</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest では、継承されたライフサイクル属性 '[TestInitialize]'、'[TestCleanup]'、'[ClassInitialize]'、'[ClassCleanup]' と、テスト属性 '[TestMethod]' および '[DataTestMethod]' が、厳密なフレームワークの型 ID で解決されます。フレームワーク アセンブリは 'Microsoft.VisualStudio.TestPlatform.TestFramework' から 'MSTest.TestFramework' に名前が変更されたため、異なる MSTest のメジャーに対してコンパイルされた基底クラスでは、異なる型 ID でこれらの属性が公開されます。こうした基底のものが、別のバージョンに対してコンパイルされたテスト クラスによって継承されると、継承されたセットアップとクリーンアップは実行されず、継承されたテスト メソッドは検出されず、ビルド エラーも検出エラーも発生しません。基本アセンブリと、カスタム属性の場合はその属性を定義しているアセンブリを、テスト プロジェクトと同じバージョンの MSTest に対して再コンパイルします。</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest では、継承されたライフサイクル属性 '[TestInitialize]'、'[TestCleanup]'、'[ClassInitialize]'、'[ClassCleanup]' と、テスト属性 '[TestMethod]' および '[DataTestMethod]' が、厳密なフレームワークの型 ID で解決されます。フレームワーク アセンブリは 'Microsoft.VisualStudio.TestPlatform.TestFramework' から 'MSTest.TestFramework' に名前が変更されたため、異なる MSTest のメジャーに対してコンパイルされた基底クラスでは、異なる型 ID でこれらの属性が公開されます。こうした基底のものが、別のバージョンに対してコンパイルされたテスト クラスによって継承されると、継承されたセットアップとクリーンアップは実行されず、継承されたテスト メソッドは検出されず、ビルド エラーも検出エラーも発生しません。基本アセンブリと、カスタム属性の場合はその属性を定義しているアセンブリを、テスト プロジェクトと同じバージョンの MSTest に対して再コンパイルします。</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' は意図的な失敗を明示し、エラー メッセージでテストを続行できない理由を文書化できるようにします。</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' は意図的な失敗を明示し、エラー メッセージでテストを続行できない理由を文書化できるようにします。</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">コンストラクターを使用すると、'readonly' フィールドを使用して初期化でき、特に null 許容参照型では、より強力なコンパイラ フィードバックが得られます。このオプトイン スタイル ルールは、MSTEST0019 と相互に排他的です。</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">コンストラクターを使用すると、'readonly' フィールドを使用して初期化でき、特に null 許容参照型では、より強力なコンパイラ フィードバックが得られます。このオプトイン スタイル ルールは、MSTEST0019 と相互に排他的です。</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' と 'DisposeAsync' は標準の .NET 有効期間パターンに従い、テストのクリーンアップを運用コードと一貫性のあるものにしています。このオプトイン スタイル ルールは、MSTEST0022 と相互に排他的です。</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' と 'DisposeAsync' は標準の .NET 有効期間パターンに従い、テストのクリーンアップを運用コードと一貫性のあるものにしています。このオプトイン スタイル ルールは、MSTEST0022 と相互に排他的です。</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' は、'IAsyncDisposable' を使用できないターゲット フレームワークでの非同期クリーンアップをサポートしています。このオプトイン スタイル ルールは、MSTEST0021 と相互に排他的です。</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' は、'IAsyncDisposable' を使用できないターゲット フレームワークでの非同期クリーンアップをサポートしています。このオプトイン スタイル ルールは、MSTEST0021 と相互に排他的です。</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' は同期および非同期初期化の両方をサポートしていますが、コンストラクターを待機することはできません。このオプトイン スタイル ルールは、MSTEST0020 と相互に排他的です。</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' は同期および非同期初期化の両方をサポートしていますが、コンストラクターを待機することはできません。このオプトイン スタイル ルールは、MSTEST0020 と相互に排他的です。</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'StringAssert' メソッドには、対応する同等の 'Assert' メソッドがあります。1 つのアサーション API を使用すると、一貫性と見つかりやすさが向上します。</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'StringAssert' メソッドには、対応する同等の 'Assert' メソッドがあります。1 つのアサーション API を使用すると、一貫性と見つかりやすさが向上します。</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest は、テスト クラスまたはテスト メソッドの外で適用されている '[DeploymentItem]' を無視します。</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest は、テスト クラスまたはテスト メソッドの外で適用されている '[DeploymentItem]' を無視します。</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -169,8 +169,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">MSTest 3.8부터 'DynamicDataSourceType.AutoDetect'는 기본값이며 속성, 메서드 및 필드를 자동으로 식별하여 세부 정보 표시 및 멤버 종류와의 결합을 줄입니다.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">MSTest 3.8부터 'DynamicDataSourceType.AutoDetect'는 기본값이며 속성, 메서드 및 필드를 자동으로 식별하여 세부 정보 표시 및 멤버 종류와의 결합을 줄입니다.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'CollectionAssert' 메서드에는 동등한 'Assert' 대응 메서드가 있습니다. 하나의 어설션 API를 사용하면 일관성과 검색 가능성이 개선됩니다.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'CollectionAssert' 메서드에는 동등한 'Assert' 대응 메서드가 있습니다. 하나의 어설션 API를 사용하면 일관성과 검색 가능성이 개선됩니다.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">어셈블리 또는 클래스 초기화에 전달된 TestContext는 해당 컨텍스트에 한정되며 각 테스트가 실행될 때마다 업데이트되지 않습니다. 'static' 멤버에서 다시 사용하면 오래된 컨텍스트가 노출될 수 있습니다.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">어셈블리 또는 클래스 초기화에 전달된 TestContext는 해당 컨텍스트에 한정되며 각 테스트가 실행될 때마다 업데이트되지 않습니다. 'static' 멤버에서 다시 사용하면 오래된 컨텍스트가 노출될 수 있습니다.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest는 상속된 수명 주기 특성 '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]', '[ClassCleanup]'와 테스트 특성 '[TestMethod]', '[DataTestMethod]'를 정확한 프레임워크 형식 ID로 확인합니다. 프레임워크 어셈블리 이름은 'Microsoft.VisualStudio.TestPlatform.TestFramework'에서 'MSTest.TestFramework'로 변경되었으므로, 다른 MSTest 주요 버전에 맞춰 컴파일된 기본 클래스는 이러한 특성을 다른 형식 ID로 노출합니다. 이런 기본 클래스를 다른 버전에 맞춰 컴파일된 테스트 클래스가 상속하면, 상속된 설정과 정리 메서드는 실행되지 않고 상속된 테스트 메서드도 검색되지 않으며, 이때 빌드 오류와 검색 오류는 발생하지 않습니다. 기본 어셈블리와, 사용자 지정 특성의 경우 해당 특성을 정의하는 어셈블리를 테스트 프로젝트와 동일한 MSTest 버전에 맞춰 다시 컴파일하세요.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest는 상속된 수명 주기 특성 '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]', '[ClassCleanup]'와 테스트 특성 '[TestMethod]', '[DataTestMethod]'를 정확한 프레임워크 형식 ID로 확인합니다. 프레임워크 어셈블리 이름은 'Microsoft.VisualStudio.TestPlatform.TestFramework'에서 'MSTest.TestFramework'로 변경되었으므로, 다른 MSTest 주요 버전에 맞춰 컴파일된 기본 클래스는 이러한 특성을 다른 형식 ID로 노출합니다. 이런 기본 클래스를 다른 버전에 맞춰 컴파일된 테스트 클래스가 상속하면, 상속된 설정과 정리 메서드는 실행되지 않고 상속된 테스트 메서드도 검색되지 않으며, 이때 빌드 오류와 검색 오류는 발생하지 않습니다. 기본 어셈블리와, 사용자 지정 특성의 경우 해당 특성을 정의하는 어셈블리를 테스트 프로젝트와 동일한 MSTest 버전에 맞춰 다시 컴파일하세요.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail'은 의도적인 실패를 명시적으로 나타내고 실패 메시지가 테스트를 계속할 수 없는 이유를 문서화할 수 있도록 합니다.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail'은 의도적인 실패를 명시적으로 나타내고 실패 메시지가 테스트를 계속할 수 없는 이유를 문서화할 수 있도록 합니다.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">생성자는 'readonly' 필드를 통해 초기화를 허용하고 특히 null 허용 참조 형식에서 더 강력한 컴파일러 피드백을 제공합니다. 이 옵트인 스타일 규칙은 MSTEST0019와 상호 배타적입니다.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">생성자는 'readonly' 필드를 통해 초기화를 허용하고 특히 null 허용 참조 형식에서 더 강력한 컴파일러 피드백을 제공합니다. 이 옵트인 스타일 규칙은 MSTEST0019와 상호 배타적입니다.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' 및 'DisposeAsync'는 표준 .NET 수명 주기 패턴을 따르므로 테스트 정리 작업을 프로덕션 코드와 일관되게 수행할 수 있습니다. 이 옵트인 스타일 규칙은 MSTEST0022와 상호 배타적입니다.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' 및 'DisposeAsync'는 표준 .NET 수명 주기 패턴을 따르므로 테스트 정리 작업을 프로덕션 코드와 일관되게 수행할 수 있습니다. 이 옵트인 스타일 규칙은 MSTEST0022와 상호 배타적입니다.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]'은 'IAsyncDisposable'을 사용할 수 없는 대상 프레임워크에서 비동기 정리를 지원합니다. 이 옵트인 스타일 규칙은 MSTEST0021과 상호 배타적입니다.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]'은 'IAsyncDisposable'을 사용할 수 없는 대상 프레임워크에서 비동기 정리를 지원합니다. 이 옵트인 스타일 규칙은 MSTEST0021과 상호 배타적입니다.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]'는 동기 및 비동기 초기화를 모두 지원하는 반면 생성자는 대기할 수 없습니다. 이 옵트인 스타일 규칙은 MSTEST0020과 상호 배타적입니다.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]'는 동기 및 비동기 초기화를 모두 지원하는 반면 생성자는 대기할 수 없습니다. 이 옵트인 스타일 규칙은 MSTEST0020과 상호 배타적입니다.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'StringAssert' 메서드에는 동등한 'Assert' 대응 메서드가 있습니다. 하나의 어설션 API를 사용하면 일관성과 검색 가능성이 개선됩니다.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'StringAssert' 메서드에는 동등한 'Assert' 대응 메서드가 있습니다. 하나의 어설션 API를 사용하면 일관성과 검색 가능성이 개선됩니다.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest는 테스트 클래스나 테스트 메서드 외부에 적용된 경우 '[DeploymentItem]'을 무시합니다.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest는 테스트 클래스나 테스트 메서드 외부에 적용된 경우 '[DeploymentItem]'을 무시합니다.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -169,8 +169,8 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">Od MSTest 3.8 'DynamicDataSourceType.AutoDetect' jest wartością domyślną i automatycznie rozpoznaje właściwości, metody i pola, zmniejszając szczegółowość oraz zależność od rodzaju składowej.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">Od MSTest 3.8 'DynamicDataSourceType.AutoDetect' jest wartością domyślną i automatycznie rozpoznaje właściwości, metody i pola, zmniejszając szczegółowość oraz zależność od rodzaju składowej.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Metody 'CollectionAssert' mają równoważne odpowiedniki 'Assert'. Używanie jednego interfejsu API do asercji poprawia spójność i odnajdywanie.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Metody 'CollectionAssert' mają równoważne odpowiedniki 'Assert'. Używanie jednego interfejsu API do asercji poprawia spójność i odnajdywanie.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">TestContext przekazany do inicjalizacji zestawu lub klasy jest specyficzny dla tego kontekstu i nie jest aktualizowany dla każdego uruchomienia testu. Ponowne użycie go w składowej 'static' może ujawnić nieaktualny kontekst.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">TestContext przekazany do inicjalizacji zestawu lub klasy jest specyficzny dla tego kontekstu i nie jest aktualizowany dla każdego uruchomienia testu. Ponowne użycie go w składowej 'static' może ujawnić nieaktualny kontekst.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">Narzędzie MSTest rozpoznaje dziedziczone atrybuty cyklu życia „[TestInitialize]”, „[TestCleanup]”, „[ClassInitialize]” i „[ClassCleanup]” oraz atrybuty testowe „[TestMethod]” i „[DataTestMethod]” według ich dokładnej tożsamości typu struktury. Nazwa zestawu struktury została zmieniona z „Microsoft.VisualStudio.TestPlatform.TestFramework” na „MSTest.TestFramework”, więc klasa bazowa skompilowana względem innego elementu głównego MSTest uwidacznia te atrybuty z inną tożsamością typu. Jeśli taka podstawa jest dziedziczona przez klasę testową skompilowaną z inną wersją, dziedziczona konfiguracja i oczyszczanie nie są uruchamiane, a dziedziczone metody testowe nie są odnajdowane, są pozbawione błędów kompilacji i błędów odnajdowania. Ponownie skompiluj zestaw podstawowy i w przypadku atrybutów niestandardowych zestaw definiujący atrybut względem tej samej wersji narzędzia MSTest co projekt testowy.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">Narzędzie MSTest rozpoznaje dziedziczone atrybuty cyklu życia „[TestInitialize]”, „[TestCleanup]”, „[ClassInitialize]” i „[ClassCleanup]” oraz atrybuty testowe „[TestMethod]” i „[DataTestMethod]” według ich dokładnej tożsamości typu struktury. Nazwa zestawu struktury została zmieniona z „Microsoft.VisualStudio.TestPlatform.TestFramework” na „MSTest.TestFramework”, więc klasa bazowa skompilowana względem innego elementu głównego MSTest uwidacznia te atrybuty z inną tożsamością typu. Jeśli taka podstawa jest dziedziczona przez klasę testową skompilowaną z inną wersją, dziedziczona konfiguracja i oczyszczanie nie są uruchamiane, a dziedziczone metody testowe nie są odnajdowane, są pozbawione błędów kompilacji i błędów odnajdowania. Ponownie skompiluj zestaw podstawowy i w przypadku atrybutów niestandardowych zestaw definiujący atrybut względem tej samej wersji narzędzia MSTest co projekt testowy.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' jawnie oznacza celowe niepowodzenie i pozwala komunikatowi o błędzie wyjaśnić, dlaczego test nie może być kontynuowany.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' jawnie oznacza celowe niepowodzenie i pozwala komunikatowi o błędzie wyjaśnić, dlaczego test nie może być kontynuowany.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">Konstruktory umożliwiają inicjowanie za pomocą pól 'readonly' i zapewniają lepsze informacje zwrotne od kompilatora, zwłaszcza w przypadku typów referencyjnych dopuszczających wartość null. Ta reguła stylu zgody na uczestnictwo wyklucza się wzajemnie z MSTEST0019.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">Konstruktory umożliwiają inicjowanie za pomocą pól 'readonly' i zapewniają lepsze informacje zwrotne od kompilatora, zwłaszcza w przypadku typów referencyjnych dopuszczających wartość null. Ta reguła stylu zgody na uczestnictwo wyklucza się wzajemnie z MSTEST0019.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' i 'DisposeAsync' są zgodne ze standardowymi wzorcami cyklu życia w .NET, dzięki czemu czyszczenie testów jest spójne z kodem produkcyjnym. Ta reguła stylu zgody na uczestnictwo wyklucza się wzajemnie z MSTEST0022.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' i 'DisposeAsync' są zgodne ze standardowymi wzorcami cyklu życia w .NET, dzięki czemu czyszczenie testów jest spójne z kodem produkcyjnym. Ta reguła stylu zgody na uczestnictwo wyklucza się wzajemnie z MSTEST0022.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' obsługuje asynchroniczne czyszczenie na platformach docelowych, na których 'IAsyncDisposable' jest niedostępny. Ta reguła stylu zgody na uczestnictwo wyklucza się wzajemnie z MSTEST0021.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' obsługuje asynchroniczne czyszczenie na platformach docelowych, na których 'IAsyncDisposable' jest niedostępny. Ta reguła stylu zgody na uczestnictwo wyklucza się wzajemnie z MSTEST0021.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' obsługuje inicjowanie synchroniczne i asynchroniczne, natomiast nie należy oczekiwać konstruktorów. Ta reguła stylu zgody na uczestnictwo wyklucza się wzajemnie z MSTEST0020.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' obsługuje inicjowanie synchroniczne i asynchroniczne, natomiast nie należy oczekiwać konstruktorów. Ta reguła stylu zgody na uczestnictwo wyklucza się wzajemnie z MSTEST0020.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Metody 'StringAssert' mają równoważne odpowiedniki 'Assert'. Używanie jednego interfejsu API do asercji poprawia spójność i odnajdywanie.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Metody 'StringAssert' mają równoważne odpowiedniki 'Assert'. Używanie jednego interfejsu API do asercji poprawia spójność i odnajdywanie.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest ignoruje '[DeploymentItem]', gdy jest on używany poza klasą testową lub metodą testową.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest ignoruje '[DeploymentItem]', gdy jest on używany poza klasą testową lub metodą testową.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -169,8 +169,8 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">Desde o MSTest 3.8, 'DynamicDataSourceType.AutoDetect' é o padrão e identifica automaticamente propriedades, métodos e campos, reduzindo a verbosidade e o acoplamento ao tipo de membro.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">Desde o MSTest 3.8, 'DynamicDataSourceType.AutoDetect' é o padrão e identifica automaticamente propriedades, métodos e campos, reduzindo a verbosidade e o acoplamento ao tipo de membro.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Os métodos 'CollectionAssert' têm equivalentes em 'Assert'. O uso de uma API de declaração melhora a consistência e a capacidade de descoberta.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Os métodos 'CollectionAssert' têm equivalentes em 'Assert'. O uso de uma API de declaração melhora a consistência e a capacidade de descoberta.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">O TestContext passado para a inicialização do assembly ou da classe é específico desse contexto e não é atualizado para cada execução de teste. Reutilizá-lo em um membro 'static' pode expor um contexto obsoleto.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">O TestContext passado para a inicialização do assembly ou da classe é específico desse contexto e não é atualizado para cada execução de teste. Reutilizá-lo em um membro 'static' pode expor um contexto obsoleto.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">O MSTest resolve os atributos de ciclo de vida herdados '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' e '[ClassCleanup]' e os atributos de teste '[TestMethod]' e '[DataTestMethod]' pela identidade exata do tipo de estrutura. O assembly da estrutura foi renomeado de 'Microsoft.VisualStudio.TestPlatform.TestFramework' para 'MSTest.TestFramework', portanto uma classe base compilada com uma versão principal diferente do MSTest expõe esses atributos com uma identidade de tipo diferente. Quando essa base é herdada por uma classe de teste compilada com outra versão, a configuração e a limpeza herdadas não são executadas e os métodos de teste herdados não são descobertos, sem erro de build nem erro de descoberta. Recompile o assembly base e, para atributos personalizados, o assembly que define o atributo na mesma versão do MSTest que o projeto de teste.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">O MSTest resolve os atributos de ciclo de vida herdados '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' e '[ClassCleanup]' e os atributos de teste '[TestMethod]' e '[DataTestMethod]' pela identidade exata do tipo de estrutura. O assembly da estrutura foi renomeado de 'Microsoft.VisualStudio.TestPlatform.TestFramework' para 'MSTest.TestFramework', portanto uma classe base compilada com uma versão principal diferente do MSTest expõe esses atributos com uma identidade de tipo diferente. Quando essa base é herdada por uma classe de teste compilada com outra versão, a configuração e a limpeza herdadas não são executadas e os métodos de teste herdados não são descobertos, sem erro de build nem erro de descoberta. Recompile o assembly base e, para atributos personalizados, o assembly que define o atributo na mesma versão do MSTest que o projeto de teste.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' torna explícita uma falha intencional e permite que a mensagem de falha documente por que o teste não pode continuar.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' torna explícita uma falha intencional e permite que a mensagem de falha documente por que o teste não pode continuar.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">Os construtores permitem a inicialização por meio de campos 'readonly' e fornecem melhor feedback do compilador, especialmente com tipos de referência anuláveis. Esta regra de estilo de aceitação é mutuamente exclusiva com MSTEST0019.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">Os construtores permitem a inicialização por meio de campos 'readonly' e fornecem melhor feedback do compilador, especialmente com tipos de referência anuláveis. Esta regra de estilo de aceitação é mutuamente exclusiva com MSTEST0019.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' e 'DisposeAsync' seguem padrões de tempo de vida padrão do .NET, tornando a limpeza de teste consistente com o código de produção. Esta regra de estilo de aceitação é mutuamente exclusiva com MSTEST0022.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' e 'DisposeAsync' seguem padrões de tempo de vida padrão do .NET, tornando a limpeza de teste consistente com o código de produção. Esta regra de estilo de aceitação é mutuamente exclusiva com MSTEST0022.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' dá suporte à limpeza assíncrona em frameworks de destino nos quais 'IAsyncDisposable' não está disponível. Esta regra de estilo de aceitação é mutuamente exclusiva com MSTEST0021.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' dá suporte à limpeza assíncrona em frameworks de destino nos quais 'IAsyncDisposable' não está disponível. Esta regra de estilo de aceitação é mutuamente exclusiva com MSTEST0021.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' dá suporte à inicialização síncrona e assíncrona, enquanto os construtores não podem ser aguardados. Esta regra de estilo de aceitação é mutuamente exclusiva com MSTEST0020.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' dá suporte à inicialização síncrona e assíncrona, enquanto os construtores não podem ser aguardados. Esta regra de estilo de aceitação é mutuamente exclusiva com MSTEST0020.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Os métodos 'StringAssert' têm equivalentes em 'Assert'. O uso de uma API de declaração melhora a consistência e a capacidade de descoberta.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Os métodos 'StringAssert' têm equivalentes em 'Assert'. O uso de uma API de declaração melhora a consistência e a capacidade de descoberta.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest ignora '[DeploymentItem]' quando ele é aplicado fora de uma classe de teste ou método de teste.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest ignora '[DeploymentItem]' quando ele é aplicado fora de uma classe de teste ou método de teste.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -169,8 +169,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">Начиная с MSTest 3.8, 'DynamicDataSourceType.AutoDetect' используется по умолчанию и автоматически определяет свойства, методы и поля, уменьшая многословность и зависимость от вида элемента.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">Начиная с MSTest 3.8, 'DynamicDataSourceType.AutoDetect' используется по умолчанию и автоматически определяет свойства, методы и поля, уменьшая многословность и зависимость от вида элемента.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Методы 'CollectionAssert' имеют эквивалентные аналоги в 'Assert'. Использование одного API утверждений улучшает согласованность и возможность обнаружения.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Методы 'CollectionAssert' имеют эквивалентные аналоги в 'Assert'. Использование одного API утверждений улучшает согласованность и возможность обнаружения.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">TestContext, переданный для инициализации сборки или класса, относится только к этому контексту и не обновляется при каждом выполнении теста. Его повторное использование в элементе 'static' может привести к предоставлению устаревшего контекста.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">TestContext, переданный для инициализации сборки или класса, относится только к этому контексту и не обновляется при каждом выполнении теста. Его повторное использование в элементе 'static' может привести к предоставлению устаревшего контекста.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest сопоставляет унаследованные атрибуты жизненного цикла "[TestInitialize]", "[TestCleanup]", "[ClassInitialize]" и "[ClassCleanup]", а также тестовые атрибуты "[TestMethod]" и "[DataTestMethod]" по их точному удостоверению типа в рамках платформы. Имя сборки платформы было изменено с "Microsoft.VisualStudio.TestPlatform.TestFramework" на "MSTest.TestFramework", поэтому базовый класс, скомпилированный для другой основной версии MSTest, предоставляет эти атрибуты с другим удостоверением типа. Если такой базовый класс наследуется классом теста, скомпилированным для другой версии, унаследованные действия настройки и очистки не выполняются, а унаследованные методы теста не обнаруживаются, при этом нет ни ошибки сборки, ни ошибки обнаружения. Перекомпилируйте базовую сборку, а для пользовательских атрибутов — сборку, в которой определен атрибут, с той же версией MSTest, что и тестовый проект.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest сопоставляет унаследованные атрибуты жизненного цикла "[TestInitialize]", "[TestCleanup]", "[ClassInitialize]" и "[ClassCleanup]", а также тестовые атрибуты "[TestMethod]" и "[DataTestMethod]" по их точному удостоверению типа в рамках платформы. Имя сборки платформы было изменено с "Microsoft.VisualStudio.TestPlatform.TestFramework" на "MSTest.TestFramework", поэтому базовый класс, скомпилированный для другой основной версии MSTest, предоставляет эти атрибуты с другим удостоверением типа. Если такой базовый класс наследуется классом теста, скомпилированным для другой версии, унаследованные действия настройки и очистки не выполняются, а унаследованные методы теста не обнаруживаются, при этом нет ни ошибки сборки, ни ошибки обнаружения. Перекомпилируйте базовую сборку, а для пользовательских атрибутов — сборку, в которой определен атрибут, с той же версией MSTest, что и тестовый проект.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' явно указывает на намеренный сбой и позволяет с помощью сообщения о сбое задокументировать, почему невозможно продолжить тест.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' явно указывает на намеренный сбой и позволяет с помощью сообщения о сбое задокументировать, почему невозможно продолжить тест.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">Конструкторы позволяют выполнять инициализацию через поля 'readonly' и обеспечивают более надежную обратную связь от компилятора, особенно при использовании ссылочных типов, допускающих значение null. Это правило согласия на стиль является взаимоисключающим с MSTEST0019.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">Конструкторы позволяют выполнять инициализацию через поля 'readonly' и обеспечивают более надежную обратную связь от компилятора, особенно при использовании ссылочных типов, допускающих значение null. Это правило согласия на стиль является взаимоисключающим с MSTEST0019.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' и 'DisposeAsync' следуют стандартным шаблонам жизненного цикла .NET, что делает очистку тестов согласованной с кодом рабочей среды. Это правило согласия на стиль является взаимоисключающим с MSTEST0022.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' и 'DisposeAsync' следуют стандартным шаблонам жизненного цикла .NET, что делает очистку тестов согласованной с кодом рабочей среды. Это правило согласия на стиль является взаимоисключающим с MSTEST0022.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' поддерживает асинхронную очистку на целевых платформах, где 'IAsyncDisposable' недоступен. Это правило согласия на стиль является взаимоисключающим с MSTEST0021.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' поддерживает асинхронную очистку на целевых платформах, где 'IAsyncDisposable' недоступен. Это правило согласия на стиль является взаимоисключающим с MSTEST0021.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' поддерживает как синхронную, так и асинхронную инициализацию, тогда как конструкторы нельзя ожидать. Это правило согласия на стиль является взаимоисключающим с MSTEST0020.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' поддерживает как синхронную, так и асинхронную инициализацию, тогда как конструкторы нельзя ожидать. Это правило согласия на стиль является взаимоисключающим с MSTEST0020.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">Методы 'StringAssert' имеют эквивалентные аналоги в 'Assert'. Использование одного API утверждений улучшает согласованность и возможность обнаружения.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">Методы 'StringAssert' имеют эквивалентные аналоги в 'Assert'. Использование одного API утверждений улучшает согласованность и возможность обнаружения.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest игнорирует '[DeploymentItem]', если его применяют вне класса теста или метода теста.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest игнорирует '[DeploymentItem]', если его применяют вне класса теста или метода теста.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -169,8 +169,8 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">MSTest 3.8'den itibaren 'DynamicDataSourceType.AutoDetect' varsayılandır ve özellikleri, yöntemleri ve alanları otomatik olarak tanımlayarak ayrıntı düzeyini ve üye türüne olan bağımlılığı azaltır.</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">MSTest 3.8'den itibaren 'DynamicDataSourceType.AutoDetect' varsayılandır ve özellikleri, yöntemleri ve alanları otomatik olarak tanımlayarak ayrıntı düzeyini ve üye türüne olan bağımlılığı azaltır.</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'CollectionAssert' yöntemlerinin eşdeğer 'Assert' karşılıkları vardır. Bir onaylama API'si kullanmak tutarlılığı ve bulunabilirliği artırır.</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'CollectionAssert' yöntemlerinin eşdeğer 'Assert' karşılıkları vardır. Bir onaylama API'si kullanmak tutarlılığı ve bulunabilirliği artırır.</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">Derleme veya sınıf başlatma için geçirilen TestContext, bu bağlama özgüdür ve her test çalıştırmasında güncellenmez. Bunu 'static' bir üyede yeniden kullanmak eski bağlamı açığa çıkarabilir.</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">Derleme veya sınıf başlatma için geçirilen TestContext, bu bağlama özgüdür ve her test çalıştırmasında güncellenmez. Bunu 'static' bir üyede yeniden kullanmak eski bağlamı açığa çıkarabilir.</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest, devralınan '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' ve '[ClassCleanup]' yaşam döngüsü öznitelikleri ile '[TestMethod]' ve '[DataTestMethod]' test özniteliklerini tam çerçeve türü kimliklerine göre çözümler. Çerçeve derlemesinin 'Microsoft.VisualStudio.TestPlatform.TestFramework' adı 'MSTest.TestFramework' olarak değiştirildi, bu nedenle farklı bir MSTest ana sürümüne göre derlenen bir temel sınıf bu öznitelikleri farklı bir tür kimliğiyle kullanıma sunuyor. Böyle bir temel, başka bir sürüme göre derlenmiş bir test sınıfı tarafından devralındığında, devralınan kurulum ve temizleme çalışmaz, ayrıca devralınan test yöntemleri bulunmaz ve derleme hatası ve keşif hatası oluşmaz. Temel derlemeyi ve özel öznitelikler için özniteliği tanımlayan derlemeyi, test projesiyle aynı MSTest sürümünde yeniden derleyin.</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest, devralınan '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' ve '[ClassCleanup]' yaşam döngüsü öznitelikleri ile '[TestMethod]' ve '[DataTestMethod]' test özniteliklerini tam çerçeve türü kimliklerine göre çözümler. Çerçeve derlemesinin 'Microsoft.VisualStudio.TestPlatform.TestFramework' adı 'MSTest.TestFramework' olarak değiştirildi, bu nedenle farklı bir MSTest ana sürümüne göre derlenen bir temel sınıf bu öznitelikleri farklı bir tür kimliğiyle kullanıma sunuyor. Böyle bir temel, başka bir sürüme göre derlenmiş bir test sınıfı tarafından devralındığında, devralınan kurulum ve temizleme çalışmaz, ayrıca devralınan test yöntemleri bulunmaz ve derleme hatası ve keşif hatası oluşmaz. Temel derlemeyi ve özel öznitelikler için özniteliği tanımlayan derlemeyi, test projesiyle aynı MSTest sürümünde yeniden derleyin.</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail', kasıtlı bir hatayı açıkça belirtir ve hata iletisinin testin neden devam edemediğini belgelemesini sağlar.</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail', kasıtlı bir hatayı açıkça belirtir ve hata iletisinin testin neden devam edemediğini belgelemesini sağlar.</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">Oluşturucular, 'readonly' alanlar üzerinden başlatmaya izin verir ve özellikle null atanabilir başvuru türlerinde daha güçlü derleyici geri bildirimi sağlar. Bu isteğe bağlı stil kuralı ile MSTEST0019 birbirini dışlar.</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">Oluşturucular, 'readonly' alanlar üzerinden başlatmaya izin verir ve özellikle null atanabilir başvuru türlerinde daha güçlü derleyici geri bildirimi sağlar. Bu isteğe bağlı stil kuralı ile MSTEST0019 birbirini dışlar.</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' ve 'DisposeAsync', standart .NET yaşam döngüsü desenlerini izler ve test temizliğini üretim koduyla tutarlı hale getirir. Bu isteğe bağlı stil kuralı ile MSTEST0022 birbirini dışlar.</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' ve 'DisposeAsync', standart .NET yaşam döngüsü desenlerini izler ve test temizliğini üretim koduyla tutarlı hale getirir. Bu isteğe bağlı stil kuralı ile MSTEST0022 birbirini dışlar.</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]', 'IAsyncDisposable' kullanılamayan hedef çerçevelerde zaman uyumsuz temizlemeyi destekler. Bu isteğe bağlı stil kuralı ile MSTEST0021 birbirini dışlar.</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]', 'IAsyncDisposable' kullanılamayan hedef çerçevelerde zaman uyumsuz temizlemeyi destekler. Bu isteğe bağlı stil kuralı ile MSTEST0021 birbirini dışlar.</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' hem zaman uyumlu hem de zaman uyumsuz başlatmayı destekler, ancak oluşturucular beklenemez. Bu isteğe bağlı stil kuralı ile MSTEST0020 birbirini dışlar.</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' hem zaman uyumlu hem de zaman uyumsuz başlatmayı destekler, ancak oluşturucular beklenemez. Bu isteğe bağlı stil kuralı ile MSTEST0020 birbirini dışlar.</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'StringAssert' yöntemlerinin eşdeğer 'Assert' karşılıkları vardır. Bir onaylama API'si kullanmak tutarlılığı ve bulunabilirliği artırır.</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'StringAssert' yöntemlerinin eşdeğer 'Assert' karşılıkları vardır. Bir onaylama API'si kullanmak tutarlılığı ve bulunabilirliği artırır.</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest, '[DeploymentItem]' bir test sınıfının veya test yönteminin dışında uygulandığında bunu yok sayar.</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest, '[DeploymentItem]' bir test sınıfının veya test yönteminin dışında uygulandığında bunu yok sayar.</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -169,8 +169,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">从 MSTest 3.8 开始，'DynamicDataSourceType.AutoDetect' 为默认值，可自动标识属性、方法和字段，从而降低详细程度并减少与成员类型的耦合。</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">从 MSTest 3.8 开始，'DynamicDataSourceType.AutoDetect' 为默认值，可自动标识属性、方法和字段，从而降低详细程度并减少与成员类型的耦合。</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'CollectionAssert' 方法具有等效的 'Assert' 对应项。使用一个断言 API 可提高一致性和可发现性。</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'CollectionAssert' 方法具有等效的 'Assert' 对应项。使用一个断言 API 可提高一致性和可发现性。</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">传递给程序集或类初始化的 TestContext 特定于该上下文，并且不会随每个测试执行进行更新。在 'static' 成员中重用它可能会公开过时的上下文。</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">传递给程序集或类初始化的 TestContext 特定于该上下文，并且不会随每个测试执行进行更新。在 'static' 成员中重用它可能会公开过时的上下文。</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest 会通过其完全相同的框架类型标识解析继承的生命周期特性 "[TestInitialize]"、"[TestCleanup]"、"[ClassInitialize]" 和 "[ClassCleanup]"，以及测试特性 "[TestMethod]" 和 "[DataTestMethod]"。框架程序集已从 "Microsoft.VisualStudio.TestPlatform.TestFramework" 重命名为 "MSTest.TestFramework"，因此针对不同 MSTest 主要版本编译的基类会以不同的类型标识公开这些特性。当测试类继承此类基类，而测试类是针对另一个版本编译时，继承的初始化和清理不会运行，继承的测试方法也不会被发现，而且不会出现生成错误或发现错误。请使用与测试项目相同的 MSTest 版本重新编译基础程序集，对于自定义特性，还要重新编译定义该特性的程序集。</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest 会通过其完全相同的框架类型标识解析继承的生命周期特性 "[TestInitialize]"、"[TestCleanup]"、"[ClassInitialize]" 和 "[ClassCleanup]"，以及测试特性 "[TestMethod]" 和 "[DataTestMethod]"。框架程序集已从 "Microsoft.VisualStudio.TestPlatform.TestFramework" 重命名为 "MSTest.TestFramework"，因此针对不同 MSTest 主要版本编译的基类会以不同的类型标识公开这些特性。当测试类继承此类基类，而测试类是针对另一个版本编译时，继承的初始化和清理不会运行，继承的测试方法也不会被发现，而且不会出现生成错误或发现错误。请使用与测试项目相同的 MSTest 版本重新编译基础程序集，对于自定义特性，还要重新编译定义该特性的程序集。</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' 可显式化处理有意失败，并允许失败消息记录测试无法继续的原因。</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' 可显式化处理有意失败，并允许失败消息记录测试无法继续的原因。</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">构造函数允许通过 'readonly' 字段进行初始化，并提供更强大的编译器反馈，对于可为 null 的引用类型尤为如此。此选择加入样式规则与 MSTEST0019 互斥。</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">构造函数允许通过 'readonly' 字段进行初始化，并提供更强大的编译器反馈，对于可为 null 的引用类型尤为如此。此选择加入样式规则与 MSTEST0019 互斥。</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' 和 'DisposeAsync' 遵循标准的 .NET 生存期模式，从而保持测试清理与生产代码处于一致状态。此选择加入样式规则与 MSTEST0022 互斥。</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' 和 'DisposeAsync' 遵循标准的 .NET 生存期模式，从而保持测试清理与生产代码处于一致状态。此选择加入样式规则与 MSTEST0022 互斥。</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' 支持在 'IAsyncDisposable' 不可用的目标框架上进行异步清理。此选择加入样式规则与 MSTEST0021 互斥。</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' 支持在 'IAsyncDisposable' 不可用的目标框架上进行异步清理。此选择加入样式规则与 MSTEST0021 互斥。</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' 同时支持同步初始化和异步初始化，但构造函数无法成为等待目标。此选择加入样式规则与 MSTEST0020 互斥。</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' 同时支持同步初始化和异步初始化，但构造函数无法成为等待目标。此选择加入样式规则与 MSTEST0020 互斥。</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'StringAssert' 方法具有等效的 'Assert' 对应项。使用一个断言 API 可提高一致性和可发现性。</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'StringAssert' 方法具有等效的 'Assert' 对应项。使用一个断言 API 可提高一致性和可发现性。</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">在测试类或测试方法外部应用时，MSTest 会忽略 '[DeploymentItem]'。</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">在测试类或测试方法外部应用时，MSTest 会忽略 '[DeploymentItem]'。</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -169,8 +169,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeDescription">
         <source>Since MSTest 3.8, 'DynamicDataSourceType.AutoDetect' is the default and automatically identifies properties, methods, and fields, reducing verbosity and coupling to the member kind.</source>
-        <target state="translated">自 MSTest 3.8 起，'DynamicDataSourceType.AutoDetect' 為預設值，會自動識別屬性、方法和欄位，減少冗長性，並降低與成員類型的耦合。</target>
-        <note>{Locked="MSTest 3.8"}{Locked="'DynamicDataSourceType.AutoDetect'"}</note>
+        <target state="needs-review-translation">自 MSTest 3.8 起，'DynamicDataSourceType.AutoDetect' 為預設值，會自動識別屬性、方法和欄位，減少冗長性，並降低與成員類型的耦合。</target>
+        <note>{Locked="MSTest 3.8"}{Locked="DynamicDataSourceType.AutoDetect"}</note>
       </trans-unit>
       <trans-unit id="AvoidExplicitDynamicDataSourceTypeMessageFormat">
         <source>Remove the 'DynamicDataSourceType' argument to use the default auto detect behavior</source>
@@ -312,8 +312,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertDescription">
         <source>'CollectionAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'CollectionAssert' 方法有對應的 'Assert' 方法。使用單一判斷提示 API 可提升一致性和可發現性。</target>
-        <note>{Locked="'CollectionAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'CollectionAssert' 方法有對應的 'Assert' 方法。使用單一判斷提示 API 可提升一致性和可發現性。</target>
+        <note>{Locked="CollectionAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="CollectionAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'CollectionAssert.{1}'</source>
@@ -417,13 +417,13 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="DoNotStoreStaticTestContextAnalyzerDescription">
         <source>The TestContext passed to assembly or class initialization is specific to that context and is not updated for each test execution. Reusing it in a 'static' member can expose stale context.</source>
-        <target state="translated">傳遞給組件或類別初始化的 TestContext 只適用於該內容，且不會在每次測試執行時更新。在 'static' 成員中重複使用它，可能會暴露過時的內容。</target>
-        <note>{Locked="TestContext"}{Locked="'static'"}</note>
+        <target state="needs-review-translation">傳遞給組件或類別初始化的 TestContext 只適用於該內容，且不會在每次測試執行時更新。在 'static' 成員中重複使用它，可能會暴露過時的內容。</target>
+        <note>{Locked="TestContext"}{Locked="static"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionDescription">
         <source>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</source>
-        <target state="translated">MSTest 會根據精確的架構類型識別，解析繼承的生命週期屬性 '[TestInitialize]'、'[TestCleanup]'、'[ClassInitialize]' 和 '[ClassCleanup]'，以及測試屬性 '[TestMethod]' 和 '[DataTestMethod]'。架構組件已從 'Microsoft.VisualStudio.TestPlatform.TestFramework' 重新命名為 'MSTest.TestFramework'，因此，若基底類別是以不同的 MSTest 主要版本編譯，就會以不同的類型識別公開這些屬性。當其他版本編譯的測試類別繼承這類基底類別時，繼承的設定與清除不會執行，繼承的測試方法也不會被探索，而且不會出現建置錯誤或探索錯誤。請使用與測試專案相同的 MSTest 版本，重新編譯基底組件，以及針對自訂屬性，定義屬性的組件。</target>
-        <note>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</note>
+        <target state="needs-review-translation">MSTest 會根據精確的架構類型識別，解析繼承的生命週期屬性 '[TestInitialize]'、'[TestCleanup]'、'[ClassInitialize]' 和 '[ClassCleanup]'，以及測試屬性 '[TestMethod]' 和 '[DataTestMethod]'。架構組件已從 'Microsoft.VisualStudio.TestPlatform.TestFramework' 重新命名為 'MSTest.TestFramework'，因此，若基底類別是以不同的 MSTest 主要版本編譯，就會以不同的類型識別公開這些屬性。當其他版本編譯的測試類別繼承這類基底類別時，繼承的設定與清除不會執行，繼承的測試方法也不會被探索，而且不會出現建置錯誤或探索錯誤。請使用與測試專案相同的 MSTest 版本，重新編譯基底組件，以及針對自訂屬性，定義屬性的組件。</target>
+        <note>{Locked="MSTest"}{Locked="[TestInitialize]"}{Locked="[TestCleanup]"}{Locked="[ClassInitialize]"}{Locked="[ClassCleanup]"}{Locked="[TestMethod]"}{Locked="[DataTestMethod]"}{Locked="Microsoft.VisualStudio.TestPlatform.TestFramework"}{Locked="MSTest.TestFramework"}</note>
       </trans-unit>
       <trans-unit id="InheritedMemberFromDifferentMSTestVersionMessageFormat">
         <source>The inherited member '{1}.{0}' is annotated with a '[{2}]' attribute that resolves to a canonical MSTest attribute in '{3}', a different MSTest framework assembly than this test project uses; MSTest matches these attributes by exact type identity, so the inherited '[{2}]' is silently ignored at run time. Recompile the assembly that declares '{1}' and, for custom attributes, the assembly that defines '[{2}]', against the same MSTest version as the test project.</source>
@@ -762,8 +762,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
-        <target state="translated">'Assert.Fail' 可明確表示刻意失敗，並讓失敗訊息說明測試為何無法繼續。</target>
-        <note>{Locked="'Assert.Fail'"}</note>
+        <target state="needs-review-translation">'Assert.Fail' 可明確表示刻意失敗，並讓失敗訊息說明測試為何無法繼續。</target>
+        <note>{Locked="Assert.Fail"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsMessageFormat">
         <source>Use 'Assert.Fail' instead of an always-failing 'Assert.{0}' assert</source>
@@ -807,23 +807,23 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="PreferConstructorOverTestInitializeDescription">
         <source>Constructors allow initialization through 'readonly' fields and provide stronger compiler feedback, especially with nullable reference types. This opt-in style rule is mutually exclusive with MSTEST0019.</source>
-        <target state="translated">建構函式可透過 'readonly' 欄位進行初始化，並提供更強的編譯器回饋，尤其是在使用可為 null 的參考型別時。此選用樣式規則與 MSTEST0019 互斥。</target>
-        <note>{Locked="'readonly'"}{Locked="MSTEST0019"}</note>
+        <target state="needs-review-translation">建構函式可透過 'readonly' 欄位進行初始化，並提供更強的編譯器回饋，尤其是在使用可為 null 的參考型別時。此選用樣式規則與 MSTEST0019 互斥。</target>
+        <note>{Locked="readonly"}{Locked="MSTEST0019"}</note>
       </trans-unit>
       <trans-unit id="PreferDisposeOverTestCleanupDescription">
         <source>'Dispose' and 'DisposeAsync' follow standard .NET lifetime patterns, making test cleanup consistent with production code. This opt-in style rule is mutually exclusive with MSTEST0022.</source>
-        <target state="translated">'Dispose' 和 'DisposeAsync' 遵循標準 .NET 存留期模式，讓測試清除與實際生產程式碼保持一致。此選用樣式規則與 MSTEST0022 互斥。</target>
-        <note>{Locked="'DisposeAsync'"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
+        <target state="needs-review-translation">'Dispose' 和 'DisposeAsync' 遵循標準 .NET 存留期模式，讓測試清除與實際生產程式碼保持一致。此選用樣式規則與 MSTEST0022 互斥。</target>
+        <note>{Locked="DisposeAsync"}{Locked="'Dispose'"}{Locked=".NET"}{Locked="MSTEST0022"}</note>
       </trans-unit>
       <trans-unit id="PreferTestCleanupOverDisposeDescription">
         <source>'[TestCleanup]' supports asynchronous cleanup on target frameworks where 'IAsyncDisposable' is unavailable. This opt-in style rule is mutually exclusive with MSTEST0021.</source>
-        <target state="translated">'[TestCleanup]' 支援在無法使用 'IAsyncDisposable' 的目標架構上進行非同步清除。此選用樣式規則與 MSTEST0021 互斥。</target>
-        <note>{Locked="'[TestCleanup]'"}{Locked="'IAsyncDisposable'"}{Locked="MSTEST0021"}</note>
+        <target state="needs-review-translation">'[TestCleanup]' 支援在無法使用 'IAsyncDisposable' 的目標架構上進行非同步清除。此選用樣式規則與 MSTEST0021 互斥。</target>
+        <note>{Locked="[TestCleanup]"}{Locked="IAsyncDisposable"}{Locked="MSTEST0021"}</note>
       </trans-unit>
       <trans-unit id="PreferTestInitializeOverConstructorDescription">
         <source>'[TestInitialize]' supports both synchronous and asynchronous initialization, whereas constructors cannot be awaited. This opt-in style rule is mutually exclusive with MSTEST0020.</source>
-        <target state="translated">'[TestInitialize]' 支援同步和非同步初始化，而建構函式無法等待。此選用樣式規則與 MSTEST0020 互斥。</target>
-        <note>{Locked="'[TestInitialize]'"}{Locked="MSTEST0020"}</note>
+        <target state="needs-review-translation">'[TestInitialize]' 支援同步和非同步初始化，而建構函式無法等待。此選用樣式規則與 MSTEST0020 互斥。</target>
+        <note>{Locked="[TestInitialize]"}{Locked="MSTEST0020"}</note>
       </trans-unit>
       <trans-unit id="PreferTestMethodOverDataTestMethodAnalyzerDescription">
         <source>'DataTestMethodAttribute' is obsolete and provides no additional functionality over 'TestMethodAttribute'. Use 'TestMethodAttribute' for all test methods, including parameterized tests.</source>
@@ -957,8 +957,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="StringAssertToAssertDescription">
         <source>'StringAssert' methods have equivalent 'Assert' counterparts. Using one assertion API improves consistency and discoverability.</source>
-        <target state="translated">'StringAssert' 方法有對應的 'Assert' 方法。使用單一判斷提示 API 可提升一致性和可發現性。</target>
-        <note>{Locked="'StringAssert'"}{Locked="'Assert'"}{Locked="API"}</note>
+        <target state="needs-review-translation">'StringAssert' 方法有對應的 'Assert' 方法。使用單一判斷提示 API 可提升一致性和可發現性。</target>
+        <note>{Locked="StringAssert"}{Locked="'Assert'"}{Locked="API"}</note>
       </trans-unit>
       <trans-unit id="StringAssertToAssertMessageFormat">
         <source>Use 'Assert.{0}' instead of 'StringAssert.{1}'</source>
@@ -1364,8 +1364,8 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassDescription">
         <source>MSTest ignores '[DeploymentItem]' when it is applied outside a test class or test method.</source>
-        <target state="translated">MSTest 會忽略在測試類別或測試方法外套用的 '[DeploymentItem]'。</target>
-        <note>{Locked="MSTest"}{Locked="'[DeploymentItem]'"}</note>
+        <target state="needs-review-translation">MSTest 會忽略在測試類別或測試方法外套用的 '[DeploymentItem]'。</target>
+        <note>{Locked="MSTest"}{Locked="[DeploymentItem]"}</note>
       </trans-unit>
       <trans-unit id="UseDeploymentItemWithTestMethodOrTestClassMessageFormat">
         <source>'[DeploymentItem]' can be specified only on test class or test method</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/CrashDumpResources.resx
@@ -172,7 +172,7 @@ Supports the following placeholders: {pname} (process executable name, deferred 
     <value>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</value>
-    <comment>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</comment>
+    <comment>Do not localize option values {Locked=&quot;&apos;on&apos;&quot;}{Locked=&quot;true&quot;}{Locked=&quot;enable&quot;}{Locked=&quot;1&quot;}{Locked=&quot;off&quot;}{Locked=&quot;false&quot;}{Locked=&quot;disable&quot;}{Locked=&quot;0&quot;}.</comment>
   </data>
   <data name="CrashSequenceOptionInvalidArgument" xml:space="preserve">
     <value>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</value>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.cs.xlf
@@ -167,10 +167,10 @@ Další informace najdete na https://learn.microsoft.com/dotnet/core/diagnostics
         <source>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</source>
-        <target state="translated">Určuje, zda se spolu s výpisem stavu systému při chybovém ukončení nebo sestavou o chybovém ukončení vygeneruje soubor sekvence uvádějící testy spuštěné a ukončené během testovací relace.
+        <target state="needs-review-translation">Určuje, zda se spolu s výpisem stavu systému při chybovém ukončení nebo sestavou o chybovém ukončení vygeneruje soubor sekvence uvádějící testy spuštěné a ukončené během testovací relace.
 Soubor umožňuje identifikovat testy, které byly spuštěny v době chybového ukončení, aniž by bylo nutné kontrolovat výpis paměti.
 Platné hodnoty jsou 'on' (výchozí; přijímá také hodnoty 'true', 'enable', '1') nebo 'off' (přijímá také hodnoty 'false', 'disable', '0').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.de.xlf
@@ -170,7 +170,7 @@ Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (al
         <target state="new">Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.es.xlf
@@ -167,10 +167,10 @@ Para obtener más información, visite https://learn.microsoft.com/dotnet/core/d
         <source>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</source>
-        <target state="translated">Controlar si se genera un archivo de secuencia que enumera las pruebas iniciadas y finalizadas durante la sesión de prueba junto con el volcado de memoria o el informe de bloqueos.
+        <target state="needs-review-translation">Controlar si se genera un archivo de secuencia que enumera las pruebas iniciadas y finalizadas durante la sesión de prueba junto con el volcado de memoria o el informe de bloqueos.
 El archivo permite identificar las pruebas que se estaban ejecutando en el momento del bloqueo sin tener que inspeccionar el volcado.
 Los valores válidos son 'on' (valor predeterminado; también acepta 'true', 'enable', '1') o 'off' (también acepta 'false', 'disable', '0').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.fr.xlf
@@ -167,10 +167,10 @@ Pour plus d’informations, visitez https://learn.microsoft.com/dotnet/core/diag
         <source>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</source>
-        <target state="translated">Contrôlez si un fichier de séquence, listant les tests démarrés et terminés au cours de la session de test, est généré parallèlement au vidage mémoire ou au rapport d'incident.
+        <target state="needs-review-translation">Contrôlez si un fichier de séquence, listant les tests démarrés et terminés au cours de la session de test, est généré parallèlement au vidage mémoire ou au rapport d'incident.
 Le fichier permet d'identifier les tests qui étaient en cours d'exécution au moment du plantage, sans avoir à inspecter le dump.
 Les valeurs valides sont 'on' (par défaut ; accepte également 'true', 'enable', '1') ou 'off' (accepte également 'false', 'disable', '0').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.it.xlf
@@ -167,10 +167,10 @@ Per altre informazioni, visitare https://learn.microsoft.com/dotnet/core/diagnos
         <source>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</source>
-        <target state="translated">Controllare se un file di sequenza che elenca i test avviati e terminati durante la sessione di test viene generato insieme al dump di arresto anomalo del sistema o al report di arresto anomalo del sistema.
+        <target state="needs-review-translation">Controllare se un file di sequenza che elenca i test avviati e terminati durante la sessione di test viene generato insieme al dump di arresto anomalo del sistema o al report di arresto anomalo del sistema.
 Il file consente di identificare i test in esecuzione al momento dell'arresto anomalo senza dover esaminare il dump.
 I valori validi sono ''on'' (impostazione predefinita; accetta anche ''true'', 'enable'', ''1'') o ''off'' (accetta anche ''false'', ''disable'', ''0'').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ja.xlf
@@ -167,10 +167,10 @@ For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/c
         <source>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</source>
-        <target state="translated">テスト セッション中に開始および終了したテストを一覧表示するシーケンス ファイルを、クラッシュ ダンプまたはクラッシュ レポートと共に生成するかどうかを制御します。
+        <target state="needs-review-translation">テスト セッション中に開始および終了したテストを一覧表示するシーケンス ファイルを、クラッシュ ダンプまたはクラッシュ レポートと共に生成するかどうかを制御します。
 このファイルを使用すると、ダンプを調べなくても、クラッシュ時に実行されていたテストを特定できます。
 有効な値は、'on' (既定値; 'true'、'enable'、'1' も指定可能)、または 'off' ('false'、'disable'、'0' も指定可能) です。</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ko.xlf
@@ -167,10 +167,10 @@ For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/c
         <source>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</source>
-        <target state="translated">테스트 세션 중에 시작되고 종료된 테스트를 나열하는 시퀀스 파일이 크래시 덤프 또는 크래시 보고서와 함께 생성되는지 여부를 제어합니다.
+        <target state="needs-review-translation">테스트 세션 중에 시작되고 종료된 테스트를 나열하는 시퀀스 파일이 크래시 덤프 또는 크래시 보고서와 함께 생성되는지 여부를 제어합니다.
 이 파일을 사용하면 덤프를 검사하지 않고도 크래시 발생 시 실행 중이던 테스트를 식별할 수 있습니다.
 유효한 값은 'on'(기본값, 'true', 'enable', '1'도 허용) 또는 'off'('false', 'disable', '0'도 허용)입니다.</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pl.xlf
@@ -170,7 +170,7 @@ Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (al
         <target state="new">Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.pt-BR.xlf
@@ -170,7 +170,7 @@ Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (al
         <target state="new">Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.ru.xlf
@@ -170,7 +170,7 @@ Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (al
         <target state="new">Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.tr.xlf
@@ -167,10 +167,10 @@ Daha fazla bilgi için https://learn.microsoft.com/dotnet/core/diagnostics/colle
         <source>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</source>
-        <target state="translated">Test oturumu sırasında başlatılan ve sonlandırılan testleri listeleyen bir sıra dosyasının kilitlenme bilgi dökümü veya kilitlenme raporuyla birlikte oluşturulup oluşturulmadığını denetleyin.
+        <target state="needs-review-translation">Test oturumu sırasında başlatılan ve sonlandırılan testleri listeleyen bir sıra dosyasının kilitlenme bilgi dökümü veya kilitlenme raporuyla birlikte oluşturulup oluşturulmadığını denetleyin.
 Dosya, dökümü incelemeye gerek kalmadan kilitlenme sırasında çalışan testlerin belirlenmesini mümkün kılar.
 Geçerli değerler: 'on' (varsayılan: 'true', 'enable', '1' değerlerini de kabul eder) ve 'off' ('false', 'disable', '0' değerlerini de kabul eder).</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hans.xlf
@@ -170,7 +170,7 @@ Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (al
         <target state="new">Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/Resources/xlf/CrashDumpResources.zh-Hant.xlf
@@ -167,10 +167,10 @@ For more information visit https://learn.microsoft.com/dotnet/core/diagnostics/c
         <source>Control whether a sequence file listing the tests started and ended during the test session is generated alongside the crash dump or crash report.
 The file makes it possible to identify the tests that were running at the time of the crash without having to inspect the dump.
 Valid values are 'on' (default; also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').</source>
-        <target state="translated">控制是否在產生損毀傾印或損毀報告時，一併產生一個列出測試工作階段期間已開始與已結束測試的序列檔案。
+        <target state="needs-review-translation">控制是否在產生損毀傾印或損毀報告時，一併產生一個列出測試工作階段期間已開始與已結束測試的序列檔案。
 這個檔案可讓您在不檢查傾印的情況下，找出發生損毀時正在執行的測試。
 有效值為 'on' (預設值，也接受 'true'、'enable'、'1') 或 'off' (也接受 'false'、'disable'、'0')。</target>
-        <note>Do not localize option name {Locked="--crash-sequence"} or option values {Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}.</note>
+        <note>Do not localize option values {Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}.</note>
       </trans-unit>
       <trans-unit id="CrashSequenceOptionInvalidArgument">
         <source>--crash-sequence expects a single parameter with value 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/ExtensionResources.resx
@@ -98,7 +98,7 @@
     <value>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</value>
-    <comment>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</comment>
+    <comment>Do not localize format name {Locked=&quot;CTRF&quot;}, placeholder tokens {Locked=&quot;{pname}&quot;}{Locked=&quot;{pid}&quot;}{Locked=&quot;{asm}&quot;}{Locked=&quot;{tfm}&quot;}{Locked=&quot;{time}&quot;}, file extension {Locked=&quot;.json&quot;}, or example file name {Locked=&quot;MyReport_{tfm}.ctrf.json&quot;}.</comment>
   </data>
   <data name="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory" xml:space="preserve">
     <value>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</value>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">Název vygenerované sestavy CTRF. Může obsahovat relativní nebo absolutní cestu. Relativní cesty se překládají na adresář výsledků testů a vytvoří se chybějící adresáře.
+        <target state="needs-review-translation">Název vygenerované sestavy CTRF. Může obsahovat relativní nebo absolutní cestu. Relativní cesty se překládají na adresář výsledků testů a vytvoří se chybějící adresáře.
 Podporuje následující zástupné symboly: {pname} (název testovací aplikace), {pid} (ID procesu), {asm} (název sestavení položky), {tfm} (moniker cílové architektury), {time} (časové razítko).
 Příklad: 'MyReport_{tfm}.ctrf.json'.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.de.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">Der Name des generierten CTRF-Berichts. Kann einen relativen oder absoluten Pfad enthalten. Relative Pfade werden anhand des Verzeichnisses mit den Testergebnissen aufgelöst, und fehlende Verzeichnisse werden erstellt.
+        <target state="needs-review-translation">Der Name des generierten CTRF-Berichts. Kann einen relativen oder absoluten Pfad enthalten. Relative Pfade werden anhand des Verzeichnisses mit den Testergebnissen aufgelöst, und fehlende Verzeichnisse werden erstellt.
 Unterstützt die folgenden Platzhalter: {pname} (Name der Testanwendung), {pid} (Prozess-ID), {asm} (Name der Eintragsassembly), {tfm} (Zielframeworkmoniker), {time} (Zeitstempel).
 Beispiel: „MyReport_{tfm}.ctrf.json“.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.es.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">Nombre del informe CTRF generado. Puede incluir una ruta de acceso relativa o absoluta; las rutas de acceso relativas se resuelven respecto al directorio de resultados de pruebas y se crean los directorios que falten.
+        <target state="needs-review-translation">Nombre del informe CTRF generado. Puede incluir una ruta de acceso relativa o absoluta; las rutas de acceso relativas se resuelven respecto al directorio de resultados de pruebas y se crean los directorios que falten.
 Admite los siguientes marcadores de posición: {pname} (nombre de la aplicación de prueba), {pid} (identificador de proceso), {asm} (nombre del ensamblado de entrada), {tfm} (moniker de la plataforma de destino), {time} (marca de tiempo).
 Ejemplo: "MyReport_{tfm}.ctrf.json".</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">Le nom du rapport CTRF généré. Peut inclure un chemin d’accès relatif ou absolu. Les chemins relatifs sont résolus sur le répertoire des résultats des tests et les répertoires manquants sont créés.
+        <target state="needs-review-translation">Le nom du rapport CTRF généré. Peut inclure un chemin d’accès relatif ou absolu. Les chemins relatifs sont résolus sur le répertoire des résultats des tests et les répertoires manquants sont créés.
 Prend en charge les espaces réservés suivants : {pname} (nom de l’application de test), {pid} (ID de processus), {asm} (nom de l’assembly d’entrée), {tfm} (moniker de framework cible), {time} (horodateur).
 Exemple : 'MyReport_{tfm}.ctrf.json'.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.it.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">Nome del report CTRF generato. Può includere un percorso relativo o assoluto; i percorsi relativi vengono risolti rispetto alla directory dei risultati dei test e le directory mancanti vengono create.
+        <target state="needs-review-translation">Nome del report CTRF generato. Può includere un percorso relativo o assoluto; i percorsi relativi vengono risolti rispetto alla directory dei risultati dei test e le directory mancanti vengono create.
 Supporta i seguenti segnaposti: {pname} (nome dell'applicazione di test), {pid} (ID processo), {asm} (nome dell'assembly di immissione), {tfm} (moniker framework di destinazione), {time} (timestamp).
 Esempio: 'MyReport_{tfm}.ctrf.json'.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">生成された CTRF レポートの名前。相対または絶対パスを含めることができます。相対パスはテスト結果ディレクトリを基準に解決され、存在しないディレクトリは作成されます。
+        <target state="needs-review-translation">生成された CTRF レポートの名前。相対または絶対パスを含めることができます。相対パスはテスト結果ディレクトリを基準に解決され、存在しないディレクトリは作成されます。
 次のプレースホルダーがサポートされています: {pname} (テスト アプリケーション名)、{pid} (プロセス ID)、{asm} (エントリ アセンブリ名)、{tfm} (ターゲット フレームワーク モニカー)、{time} (タイムスタンプ)。
 例: 'MyReport_{tfm}.ctrf.json'。</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">생성된 CTRF 보고서의 이름입니다. 상대 경로 또는 절대 경로를 사용할 수 있습니다. 상대 경로는 테스트 결과 디렉터리를 기준으로 확인되며, 없는 디렉터리는 만들어집니다.
+        <target state="needs-review-translation">생성된 CTRF 보고서의 이름입니다. 상대 경로 또는 절대 경로를 사용할 수 있습니다. 상대 경로는 테스트 결과 디렉터리를 기준으로 확인되며, 없는 디렉터리는 만들어집니다.
 자리 표시자 {pname}(테스트 애플리케이션 이름), {pid}(프로세스 ID), {asm}(항목 어셈블리 이름), {tfm}(대상 프레임워크 모니커), {time}(타임스탬프)을(를) 지원합니다.
 예: 'MyReport_{tfm}.ctrf.json'.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">Nazwa wygenerowanego raportu CTRF. Może zawierać ścieżkę względną lub bezwzględną; ścieżki względne są rozpoznawane względem katalogu wyników testów, a brakujące katalogi są tworzone.
+        <target state="needs-review-translation">Nazwa wygenerowanego raportu CTRF. Może zawierać ścieżkę względną lub bezwzględną; ścieżki względne są rozpoznawane względem katalogu wyników testów, a brakujące katalogi są tworzone.
 Obsługuje następujące symbole zastępcze: {pname} (nazwa aplikacji testowej), {pid} (identyfikator procesu), {asm} (nazwa zestawu wejściowego), {tfm} (moniker platformy docelowej), {time} (sygnatura czasowa).
 Przykład: „MyReport_{tfm}.ctrf.json”.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">O nome do relatório CTRF gerado. Pode incluir um caminho relativo ou absoluto; os caminhos relativos são resolvidos em relação ao diretório de resultados de teste, e os diretórios ausentes são criados.
+        <target state="needs-review-translation">O nome do relatório CTRF gerado. Pode incluir um caminho relativo ou absoluto; os caminhos relativos são resolvidos em relação ao diretório de resultados de teste, e os diretórios ausentes são criados.
 Dá suporte aos seguintes espaços reservados: {pname} (nome do aplicativo de teste), {pid} (ID do processo), {asm} (nome do assembly de entrada), {tfm} (moniker da estrutura de destino), {time} (carimbo de data/hora).
 Exemplo: 'MyReport_{tfm}.ctrf.json'.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">Название сформированного отчета CTRF. Может включать относительный или абсолютный путь; относительные пути разрешаются относительно каталога результатов тестов, а отсутствующие каталоги создаются.
+        <target state="needs-review-translation">Название сформированного отчета CTRF. Может включать относительный или абсолютный путь; относительные пути разрешаются относительно каталога результатов тестов, а отсутствующие каталоги создаются.
 Поддерживаются следующие заполнители: {pname} (имя тестового приложения), {pid} (идентификатор процесса), {asm} (имя входной сборки), {tfm} (моникер целевой платформы), {time} (метка времени).
 Пример: 'MyReport_{tfm}.ctrf.json'.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">Oluşturulan CTRF raporunun adı. Göreli veya mutlak yol içerebilir; göreli yollar test sonuçları dizinine göre çözülmüş ve eksik dizinler oluşturulur.
+        <target state="needs-review-translation">Oluşturulan CTRF raporunun adı. Göreli veya mutlak yol içerebilir; göreli yollar test sonuçları dizinine göre çözülmüş ve eksik dizinler oluşturulur.
 Şu yer tutucuları destekler: {pname} (test uygulaması adı), {pid} (işlem kimliği), {asm} (girdi derleme adı), {tfm} (hedef çerçeve bilinen adı), {time} (zaman damgası).
 Örnek: 'MyReport_{tfm}.ctrf.json'.</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">生成的 CTRF 报表的名称。可以包含相对路径或绝对路径；相对路径针对测试结果目录进行解析，并创建缺少的目录。
+        <target state="needs-review-translation">生成的 CTRF 报表的名称。可以包含相对路径或绝对路径；相对路径针对测试结果目录进行解析，并创建缺少的目录。
 支持以下占位符: {pname} (测试应用程序名称)、{pid} (进程 ID)、{asm} (入口程序集名称)、{tfm} (目标框架名字对象)、{time} (时间戳)。
 示例: "MyReport_{tfm}.ctrf.json"。</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -51,10 +51,10 @@
         <source>The name of the generated CTRF report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {time} (timestamp).
 Example: 'MyReport_{tfm}.ctrf.json'.</source>
-        <target state="translated">產生的 CTRF 報告名稱。可以包含相對或絕對路徑; 系統會針對測試結果目錄解析相對路徑，並建立遺漏的目錄。
+        <target state="needs-review-translation">產生的 CTRF 報告名稱。可以包含相對或絕對路徑; 系統會針對測試結果目錄解析相對路徑，並建立遺漏的目錄。
 支援下列預留位置: {pname}(測試應用程式名稱)、{pid}(處理序識別碼)、{asm}(進入組件名稱)、{tfm}(目標 Framework Moniker)、{time}(時間戳記)。
 範例: 'MyReport_{tfm}.ctrf.json'。</target>
-        <note>Do not localize option name {Locked="--report-ctrf-filename"}, format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="'MyReport_{tfm}.ctrf.json'"}.</note>
+        <note>Do not localize format name {Locked="CTRF"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{time}"}, file extension {Locked=".json"}, or example file name {Locked="MyReport_{tfm}.ctrf.json"}.</note>
       </trans-unit>
       <trans-unit id="CtrfReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-ctrf-filename' relative paths must stay under the test results directory (e.g. --report-ctrf-filename nested/myreport.ctrf.json)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/GitHubActionsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/GitHubActionsResources.resx
@@ -81,19 +81,19 @@
   </data>
   <data name="StepSummaryOptionDescription" xml:space="preserve">
     <value>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</value>
-    <comment>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</comment>
+    <comment>{Locked=&quot;&apos;on&apos;&quot;}{Locked=&quot;off&quot;}{Locked=&quot;true&quot;}{Locked=&quot;enable&quot;}{Locked=&quot;1&quot;}{Locked=&quot;false&quot;}{Locked=&quot;disable&quot;}{Locked=&quot;0&quot;}{Locked=&quot;on-failure&quot;}{Locked=&quot;GITHUB_STEP_SUMMARY&quot;}</comment>
   </data>
   <data name="StepSummarySectionsOptionDescription" xml:space="preserve">
     <value>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</value>
-    <comment>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</comment>
+    <comment>{Locked=&quot;test-results&quot;}{Locked=&quot;slow-tests&quot;}{Locked=&quot;coverage&quot;}{Locked=&quot;all&quot;}{Locked=&quot;--report-gh&quot;}</comment>
   </data>
   <data name="EmptyStepSummarySections" xml:space="preserve">
     <value>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</value>
-    <comment>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</comment>
+    <comment>{Locked=&quot;test-results&quot;}{Locked=&quot;slow-tests&quot;}{Locked=&quot;coverage&quot;}{Locked=&quot;all&quot;}</comment>
   </data>
   <data name="InvalidStepSummarySection" xml:space="preserve">
     <value>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</value>
-    <comment>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</comment>
+    <comment>{0} is the invalid section name. {Locked=&quot;test-results&quot;}{Locked=&quot;slow-tests&quot;}{Locked=&quot;coverage&quot;}{Locked=&quot;all&quot;}</comment>
   </data>
   <data name="StepSummaryWriteFailedWarning" xml:space="preserve">
     <value>Failed to write the GitHub Actions job summary to '{0}': {1}</value>
@@ -132,11 +132,11 @@
   </data>
   <data name="HistoryOptionDescription" xml:space="preserve">
     <value>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</value>
-    <comment>{Locked="'--report-gh'"}</comment>
+    <comment>{Locked=&quot;--report-gh&quot;}</comment>
   </data>
   <data name="HistoryWindowOptionDescription" xml:space="preserve">
     <value>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</value>
-    <comment>{Locked="'--report-gh-history'"}</comment>
+    <comment>{Locked=&quot;--report-gh-history&quot;}</comment>
   </data>
   <data name="InvalidHistoryWindow" xml:space="preserve">
     <value>Invalid GitHub Actions test history window '{0}'. Specify a whole number of days from 1 through 90.</value>
@@ -147,7 +147,7 @@
   </data>
   <data name="HistoryWindowRequiresHistory" xml:space="preserve">
     <value>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</value>
-    <comment>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</comment>
+    <comment>{Locked=&quot;--report-gh-history-window&quot;}{Locked=&quot;&apos;--report-gh-history&apos;&quot;}</comment>
   </data>
   <data name="HistoryLoadFailedWarning" xml:space="preserve">
     <value>Failed to load the GitHub Actions test history snapshot from '{0}': {1}</value>
@@ -179,11 +179,11 @@
   </data>
   <data name="InvalidStepSummaryValue" xml:space="preserve">
     <value>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</value>
-    <comment>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</comment>
+    <comment>{Locked=&quot;&apos;on&apos;&quot;}{Locked=&quot;off&quot;}{Locked=&quot;true&quot;}{Locked=&quot;enable&quot;}{Locked=&quot;1&quot;}{Locked=&quot;false&quot;}{Locked=&quot;disable&quot;}{Locked=&quot;&apos;0&apos;&quot;}{Locked=&quot;on-failure&quot;}{0} is the invalid value.</comment>
   </data>
   <data name="SubOptionsRequireReportGh" xml:space="preserve">
     <value>The GitHub Actions report sub-options require '--{0}' to be specified.</value>
-    <comment>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</comment>
+    <comment>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked=&quot;--{0}&quot;}</comment>
   </data>
   <data name="OptionDescription" xml:space="preserve">
     <value>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</value>
@@ -248,7 +248,7 @@
   </data>
   <data name="FailureDetailsOptionDescription" xml:space="preserve">
     <value>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</value>
-    <comment>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</comment>
+    <comment>{Locked=&quot;&apos;on&apos;&quot;}{Locked=&quot;off&quot;}{Locked=&quot;true&quot;}{Locked=&quot;enable&quot;}{Locked=&quot;1&quot;}{Locked=&quot;false&quot;}{Locked=&quot;&apos;disable&apos;&quot;}{Locked=&quot;0&quot;}</comment>
   </data>
   <data name="FailureDetailExceptionLabel" xml:space="preserve">
     <value>Exception</value>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.cs.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">Je vyžadováno alespoň jedno oddělení souhrnu úlohy GitHub Actions. Platné hodnoty jsou 'test-results', 'slow-tests', 'coverage' nebo 'all'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Je vyžadováno alespoň jedno oddělení souhrnu úlohy GitHub Actions. Platné hodnoty jsou 'test-results', 'slow-tests', 'coverage' nebo 'all'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Povolte nebo zakažte rozbalení každého neúspěšného testu v souhrnu úlohy do sbalitelné části se zprávou o chybě, typem výjimky, umístěním zdroje a trasováním zásobníku. Platné hodnoty jsou 'on' (přijímá také hodnoty 'true', 'enable', '1') nebo 'off' (přijímá také hodnoty 'false', 'disable', '0'). Při spuštění na GitHub Actions je výchozí hodnota 'on'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">Povolte nebo zakažte rozbalení každého neúspěšného testu v souhrnu úlohy do sbalitelné části se zprávou o chybě, typem výjimky, umístěním zdroje a trasováním zásobníku. Platné hodnoty jsou 'on' (přijímá také hodnoty 'true', 'enable', '1') nebo 'off' (přijímá také hodnoty 'false', 'disable', '0'). Při spuštění na GitHub Actions je výchozí hodnota 'on'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Na zadané cestě načte a aktualizuje omezený snímek historie testů GitHub Actions. Workflow musí před spuštěním testu stáhnout předchozí snímek a po testu nahrát aktualizovaný soubor. Vyžaduje --report-gh.</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Na zadané cestě načte a aktualizuje omezený snímek historie testů GitHub Actions. Workflow musí před spuštěním testu stáhnout předchozí snímek a po testu nahrát aktualizovaný soubor. Vyžaduje --report-gh.</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Počet dnů historie testů, které se mají uchovávat a používat jako kontext nestabilních testů (1–90). Výchozí hodnota je 30. Vyžaduje --report-gh-history.</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Počet dnů historie testů, které se mají uchovávat a používat jako kontext nestabilních testů (1–90). Výchozí hodnota je 30. Vyžaduje --report-gh-history.</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
         <target state="new">The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">Neplatná část souhrnu úlohy GitHub Actions '{0}'. Platné hodnoty jsou 'test-results', 'slow-tests', 'coverage' nebo 'all'. Hodnoty se můžou opakovat a můžou být oddělené mezerami nebo čárkami.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Neplatná část souhrnu úlohy GitHub Actions '{0}'. Platné hodnoty jsou 'test-results', 'slow-tests', 'coverage' nebo 'all'. Hodnoty se můžou opakovat a můžou být oddělené mezerami nebo čárkami.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">Neplatná hodnota '{0}'. Platné hodnoty jsou 'on' (nebo 'true', 'enable', '1'), 'off' (nebo 'false', 'disable', '0') nebo 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">Neplatná hodnota '{0}'. Platné hodnoty jsou 'on' (nebo 'true', 'enable', '1'), 'off' (nebo 'false', 'disable', '0') nebo 'on-failure'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -290,12 +290,12 @@
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">Vyberte obsah zahrnutý do souhrnu úlohy GitHub Actions. Zadejte jednu nebo více hodnot, opakovaně, oddělených mezerami nebo čárkami: 'test-results', 'slow-tests', 'coverage' nebo 'all'. Výchozí hodnota je 'all'. Vyžaduje '--report-gh'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Vyberte obsah zahrnutý do souhrnu úlohy GitHub Actions. Zadejte jednu nebo více hodnot, opakovaně, oddělených mezerami nebo čárkami: 'test-results', 'slow-tests', 'coverage' nebo 'all'. Výchozí hodnota je 'all'. Vyžaduje '--report-gh'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">Dílčí možnosti sestavy GitHub Actions vyžadují zadání parametru '--{0}'.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">Dílčí možnosti sestavy GitHub Actions vyžadují zadání parametru '--{0}'.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.de.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">Mindestens ein Abschnitt der Auftragszusammenfassung für GitHub Actions ist erforderlich. Gültige Werte sind 'test-results', 'slow-tests', 'coverage', oder 'all'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Mindestens ein Abschnitt der Auftragszusammenfassung für GitHub Actions ist erforderlich. Gültige Werte sind 'test-results', 'slow-tests', 'coverage', oder 'all'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Aktivieren oder deaktivieren Sie, dass jeder fehlgeschlagene Test in der Jobzusammenfassung in einen einklappbaren Abschnitt mit Fehlermeldung, Ausnahmetyp, Quellposition und Stacktrace erweitert wird. Gültige Werte sind 'on' (akzeptiert auch 'true', 'enable', '1') oder 'off' (akzeptiert auch 'false', 'disable', '0'). Der Standardwert ist 'on', wenn die Ausführung auf GitHub Actions erfolgt.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">Aktivieren oder deaktivieren Sie, dass jeder fehlgeschlagene Test in der Jobzusammenfassung in einen einklappbaren Abschnitt mit Fehlermeldung, Ausnahmetyp, Quellposition und Stacktrace erweitert wird. Gültige Werte sind 'on' (akzeptiert auch 'true', 'enable', '1') oder 'off' (akzeptiert auch 'false', 'disable', '0'). Der Standardwert ist 'on', wenn die Ausführung auf GitHub Actions erfolgt.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Liest eine begrenzte Momentaufnahme des GitHub Actions Testverlaufs am angegebenen Pfad und aktualisiert ihn. Der Workflow ist dafür verantwortlich, die vorherige Momentaufnahme vor dem Testlauf herunterzuladen und die aktualisierte Datei anschließend hochzuladen. Erfordert '--report-gh'.</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Liest eine begrenzte Momentaufnahme des GitHub Actions Testverlaufs am angegebenen Pfad und aktualisiert ihn. Der Workflow ist dafür verantwortlich, die vorherige Momentaufnahme vor dem Testlauf herunterzuladen und die aktualisierte Datei anschließend hochzuladen. Erfordert '--report-gh'.</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Anzahl der Tage des Testverlaufs, die aufbewahrt und für den Kontext zu instabilen Tests verwendet werden sollen (1–90). Standardwert ist 30. Erfordert '--report-gh-history'.</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Anzahl der Tage des Testverlaufs, die aufbewahrt und für den Kontext zu instabilen Tests verwendet werden sollen (1–90). Standardwert ist 30. Erfordert '--report-gh-history'.</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
-        <target state="translated">Die Option '--report-gh-history-window' erfordert, dass '--report-gh-history' angegeben wird.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Die Option '--report-gh-history-window' erfordert, dass '--report-gh-history' angegeben wird.</target>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">Ungültiger Abschnitt „{0}“ in der Auftragszusammenfassung für GitHub Actions. Gültige Werte sind 'test-results', 'slow-tests', 'coverage' oder 'all'. Werte können wiederholt, durch Leerzeichen getrennt oder durch Kommas getrennt werden.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Ungültiger Abschnitt „{0}“ in der Auftragszusammenfassung für GitHub Actions. Gültige Werte sind 'test-results', 'slow-tests', 'coverage' oder 'all'. Werte können wiederholt, durch Leerzeichen getrennt oder durch Kommas getrennt werden.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">Ungültiger Wert: „{0}“. Gültige Werte sind 'on' (oder 'true', 'enable', '1'), 'off' (oder 'false', 'disable', '0'), oder 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">Ungültiger Wert: „{0}“. Gültige Werte sind 'on' (oder 'true', 'enable', '1'), 'off' (oder 'false', 'disable', '0'), oder 'on-failure'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -290,12 +290,12 @@
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">Wählen Sie den Inhalt aus, der in der Auftragszusammenfassung für GitHub Actions enthalten ist. Geben Sie einen oder mehrere Werte an, die wiederholt, durch Leerzeichen oder durch Kommas getrennt sein können: 'test-results', 'slow-tests', 'coverage' oder 'all'. Der Standardwert lautet 'all'. Erfordert '--report-gh'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Wählen Sie den Inhalt aus, der in der Auftragszusammenfassung für GitHub Actions enthalten ist. Geben Sie einen oder mehrere Werte an, die wiederholt, durch Leerzeichen oder durch Kommas getrennt sein können: 'test-results', 'slow-tests', 'coverage' oder 'all'. Der Standardwert lautet 'all'. Erfordert '--report-gh'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">Für die Unteroptionen des GitHub Actions-Berichts muss '--{0}' angegeben werden.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">Für die Unteroptionen des GitHub Actions-Berichts muss '--{0}' angegeben werden.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.es.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">Se requiere al menos una sección de resumen del trabajo de Acciones de GitHub. Los valores válidos son 'test-results', 'slow-tests', 'coverage' o 'all'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Se requiere al menos una sección de resumen del trabajo de Acciones de GitHub. Los valores válidos son 'test-results', 'slow-tests', 'coverage' o 'all'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Habilite o deshabilite la expansión de cada prueba con errores en el resumen del trabajo en una sección contraíble con su mensaje de error, tipo de excepción, ubicación de origen y seguimiento de pila. Los valores válidos son 'on' (también acepta 'true', 'enable', '1') o 'off' (también acepta 'false', 'disable', '0'). El valor predeterminado es 'on' cuando se ejecuta en Acciones de GitHub.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">Habilite o deshabilite la expansión de cada prueba con errores en el resumen del trabajo en una sección contraíble con su mensaje de error, tipo de excepción, ubicación de origen y seguimiento de pila. Los valores válidos son 'on' (también acepta 'true', 'enable', '1') o 'off' (también acepta 'false', 'disable', '0'). El valor predeterminado es 'on' cuando se ejecuta en Acciones de GitHub.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Leer y actualizar una instantánea del historial de pruebas de Acciones de GitHub limitada en la ruta de acceso especificada. El flujo de trabajo es responsable de descargar la instantánea anterior antes de la ejecución de la prueba y de cargar el archivo actualizado posteriormente. Requiere "--report-gh".</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Leer y actualizar una instantánea del historial de pruebas de Acciones de GitHub limitada en la ruta de acceso especificada. El flujo de trabajo es responsable de descargar la instantánea anterior antes de la ejecución de la prueba y de cargar el archivo actualizado posteriormente. Requiere "--report-gh".</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Número de días del historial de pruebas que se conservarán y usarán para el contexto de prueba no confiable (1-90). El valor predeterminado es 30. Requiere "--report-gh-history".</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Número de días del historial de pruebas que se conservarán y usarán para el contexto de prueba no confiable (1-90). El valor predeterminado es 30. Requiere "--report-gh-history".</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
         <target state="new">The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">La sección de resumen del trabajo de GitHub Actions '{0}' no es válida. Los valores válidos son 'test-results', 'slow-tests', 'coverage' o 'all'. Los valores pueden repetirse, separarse por espacios o por comas.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">La sección de resumen del trabajo de GitHub Actions '{0}' no es válida. Los valores válidos son 'test-results', 'slow-tests', 'coverage' o 'all'. Los valores pueden repetirse, separarse por espacios o por comas.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">Valor no válido '{0}'. Los valores válidos son 'on' (o 'true', 'enable', '1'), 'off' (o 'false', 'disable', '0') o 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">Valor no válido '{0}'. Los valores válidos son 'on' (o 'true', 'enable', '1'), 'off' (o 'false', 'disable', '0') o 'on-failure'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -290,12 +290,12 @@
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">Seleccione el contenido incluido en el resumen del trabajo de Acciones de GitHub. Especifique uno o varios valores, repetidos, separados por espacios o separados por comas: 'test-results', 'slow-tests', 'coverage' o 'all'. El valor predeterminado es 'all'. Requiere '--report-gh'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Seleccione el contenido incluido en el resumen del trabajo de Acciones de GitHub. Especifique uno o varios valores, repetidos, separados por espacios o separados por comas: 'test-results', 'slow-tests', 'coverage' o 'all'. El valor predeterminado es 'all'. Requiere '--report-gh'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">Las subopciones del informe de GitHub Actions requieren especificar '--{0}'.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">Las subopciones del informe de GitHub Actions requieren especificar '--{0}'.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.fr.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">Au moins une section du résumé de travail GitHub Actions est requise. Les valeurs valides sont 'test-results', 'slow-tests', 'coverage' ou 'all'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Au moins une section du résumé de travail GitHub Actions est requise. Les valeurs valides sont 'test-results', 'slow-tests', 'coverage' ou 'all'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Activez ou désactivez l’affichage de chaque test en échec dans le résumé du travail sous forme de section réductible avec son message d’échec, son type d’exception, son emplacement source et sa trace de pile. Les valeurs valides sont 'on' (par défaut, accepte également 'true', 'enable', '1') ou 'off' (accepte également 'false', 'disable', '0'). La valeur par défaut est 'on' lors de l’exécution sur GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">Activez ou désactivez l’affichage de chaque test en échec dans le résumé du travail sous forme de section réductible avec son message d’échec, son type d’exception, son emplacement source et sa trace de pile. Les valeurs valides sont 'on' (par défaut, accepte également 'true', 'enable', '1') ou 'off' (accepte également 'false', 'disable', '0'). La valeur par défaut est 'on' lors de l’exécution sur GitHub Actions.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Lire et mettre à jour un instantané limité de l'historique des tests GitHub Actions au chemin spécifié. Le flux de travail est chargé de télécharger l’instantané précédent avant la série de tests et de charger le fichier mis à jour par la suite. Nécessite '--report-gh'.</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Lire et mettre à jour un instantané limité de l'historique des tests GitHub Actions au chemin spécifié. Le flux de travail est chargé de télécharger l’instantané précédent avant la série de tests et de charger le fichier mis à jour par la suite. Nécessite '--report-gh'.</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Nombre de jours d'historique de tests à conserver et à utiliser pour le contexte des tests instables (1 à 90). La valeur par défaut est 30. Nécessite '--report-gh-history'.</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Nombre de jours d'historique de tests à conserver et à utiliser pour le contexte des tests instables (1 à 90). La valeur par défaut est 30. Nécessite '--report-gh-history'.</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
-        <target state="translated">L'option '--report-gh-history-window' nécessite que '--report-gh-history' soit spécifiée.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">L'option '--report-gh-history-window' nécessite que '--report-gh-history' soit spécifiée.</target>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">Section du résumé de travail GitHub Actions '{0}' non valide. Les valeurs valides sont 'test-results', 'slow-tests', 'coverage' ou 'all'. Vous pouvez répéter des valeurs ou les séparer par des espaces ou des virgules.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Section du résumé de travail GitHub Actions '{0}' non valide. Les valeurs valides sont 'test-results', 'slow-tests', 'coverage' ou 'all'. Vous pouvez répéter des valeurs ou les séparer par des espaces ou des virgules.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">Valeur '{0}' non valide. Les valeurs valides sont 'on' (ou 'true', 'enable', '1'), 'off' (ou 'false', 'disable', '0') ou 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">Valeur '{0}' non valide. Les valeurs valides sont 'on' (ou 'true', 'enable', '1'), 'off' (ou 'false', 'disable', '0') ou 'on-failure'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -290,12 +290,12 @@
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">Sélectionnez le contenu inclus dans le résumé du travail GitHub Actions. Spécifiez une ou plusieurs valeurs, répétées, séparées par des espaces ou des virgules : 'test-results', 'slow-tests', 'coverage' ou 'all'. Prend la valeur 'all' par défaut. Nécessite '--report-gh'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Sélectionnez le contenu inclus dans le résumé du travail GitHub Actions. Spécifiez une ou plusieurs valeurs, répétées, séparées par des espaces ou des virgules : 'test-results', 'slow-tests', 'coverage' ou 'all'. Prend la valeur 'all' par défaut. Nécessite '--report-gh'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">Les sous-options du rapport GitHub Actions nécessitent que l’option « --{0} » soit spécifiée.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">Les sous-options du rapport GitHub Actions nécessitent que l’option « --{0} » soit spécifiée.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.it.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">È richiesta almeno una sezione di riepilogo del processo di GitHub Actions. I valori validi sono 'test-results', 'slow-tests', 'coverage' o 'all'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">È richiesta almeno una sezione di riepilogo del processo di GitHub Actions. I valori validi sono 'test-results', 'slow-tests', 'coverage' o 'all'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Abilitare o disabilitare l'espansione di ogni test non superato nel riepilogo di processo in una sezione comprimibile contenente il messaggio di errore, il tipo di eccezione, il percorso di origine e l'analisi dello stack. I valori validi sono 'on' (accetta anche 'true', 'enable', '1') o 'off' (accetta anche 'false', 'disable', '0'). Il valore predefinito è 'on' quando si esegue in GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">Abilitare o disabilitare l'espansione di ogni test non superato nel riepilogo di processo in una sezione comprimibile contenente il messaggio di errore, il tipo di eccezione, il percorso di origine e l'analisi dello stack. I valori validi sono 'on' (accetta anche 'true', 'enable', '1') o 'off' (accetta anche 'false', 'disable', '0'). Il valore predefinito è 'on' quando si esegue in GitHub Actions.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Leggere e aggiornare uno snapshot con vincoli della cronologia dei test di GitHub Actions nel percorso specificato. Il flusso di lavoro è responsabile del download dello snapshot precedente prima dell'esecuzione dei test e del caricamento del file aggiornato al termine. Richiede '--report-gh'.</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Leggere e aggiornare uno snapshot con vincoli della cronologia dei test di GitHub Actions nel percorso specificato. Il flusso di lavoro è responsabile del download dello snapshot precedente prima dell'esecuzione dei test e del caricamento del file aggiornato al termine. Richiede '--report-gh'.</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Numero di giorni di cronologia dei test da conservare e usare per il contesto dei test inattendibili (1-90). Il valore predefinito è 30. Richiede '--report-gh-history'.</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Numero di giorni di cronologia dei test da conservare e usare per il contesto dei test inattendibili (1-90). Il valore predefinito è 30. Richiede '--report-gh-history'.</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
-        <target state="translated">L'opzione '--report-gh-history-window' richiede che sia specificato '--report-gh-history'.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">L'opzione '--report-gh-history-window' richiede che sia specificato '--report-gh-history'.</target>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">Sezione di riepilogo del processo di GitHub Actions non valida: '{0}'. I valori validi sono 'test-results', 'slow-tests', 'coverage' o 'all'. I valori possono essere ripetuti, separati da spazi o da virgole.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Sezione di riepilogo del processo di GitHub Actions non valida: '{0}'. I valori validi sono 'test-results', 'slow-tests', 'coverage' o 'all'. I valori possono essere ripetuti, separati da spazi o da virgole.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">Valore '{0}' non valido. I valori validi sono 'on' (o 'true', 'enable', '1'), 'off' (o 'false', 'disable', '0') o 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">Valore '{0}' non valido. I valori validi sono 'on' (o 'true', 'enable', '1'), 'off' (o 'false', 'disable', '0') o 'on-failure'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -289,13 +289,13 @@
       </trans-unit>
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Consente di controllare la scrittura di un riepilogo del processo in Markdown nel file GITHUB_STEP_SUMMARY. I valori validi sono 'on' (accetta anche 'true', 'enable', '1'), 'off' (accetta anche 'false', 'disable', '0') oppure 'on-failure' per scrivere il riepilogo solo quando l'esecuzione del test fallisce. Il valore predefinito è 'on' quando si esegue in GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <target state="needs-review-translation">Consente di controllare la scrittura di un riepilogo del processo in Markdown nel file GITHUB_STEP_SUMMARY. I valori validi sono 'on' (accetta anche 'true', 'enable', '1'), 'off' (accetta anche 'false', 'disable', '0') oppure 'on-failure' per scrivere il riepilogo solo quando l'esecuzione del test fallisce. Il valore predefinito è 'on' quando si esegue in GitHub Actions.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">Selezionare il contenuto da includere nel riepilogo del processo di GitHub Actions. Specificare uno o più valori, anche ripetuti, separati da spazi o da virgole: 'test-results', 'slow-tests', 'coverage' o 'all'. Il valore predefinito è 'all'. Richiede '--report-gh'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Selezionare il contenuto da includere nel riepilogo del processo di GitHub Actions. Specificare uno o più valori, anche ripetuti, separati da spazi o da virgole: 'test-results', 'slow-tests', 'coverage' o 'all'. Il valore predefinito è 'all'. Richiede '--report-gh'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">È necessario specificare '--{0}' per le opzioni secondarie del report di GitHub Actions.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">È necessario specificare '--{0}' per le opzioni secondarie del report di GitHub Actions.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ja.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">少なくとも 1 つの GitHub Actions ジョブの要約セクションが必要です。有効な値は 'test-results'、'slow-tests'、'coverage'、または 'all' です。</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">少なくとも 1 つの GitHub Actions ジョブの要約セクションが必要です。有効な値は 'test-results'、'slow-tests'、'coverage'、または 'all' です。</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">ジョブ概要で失敗した各テストを、失敗メッセージ、例外の種類、ソースの場所、スタック トレースを含む折りたたみ可能なセクションとして表示する機能を有効または無効にします。有効な値は、'on' ('true'、'enable'、'1' も指定可能)、または 'off' ('false'、'disable'、'0' も指定可能) です。GitHub Actions で実行する場合、既定値は 'on' です。</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">ジョブ概要で失敗した各テストを、失敗メッセージ、例外の種類、ソースの場所、スタック トレースを含む折りたたみ可能なセクションとして表示する機能を有効または無効にします。有効な値は、'on' ('true'、'enable'、'1' も指定可能)、または 'off' ('false'、'disable'、'0' も指定可能) です。GitHub Actions で実行する場合、既定値は 'on' です。</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">指定されたパスで、制限付きの GitHub Actions テスト履歴スナップショットを読み取り、更新します。このワークフローは、テスト実行前に前回のスナップショットをダウンロードし、その後で更新済みのファイルをアップロードします。'--report-gh' が必要です。</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">指定されたパスで、制限付きの GitHub Actions テスト履歴スナップショットを読み取り、更新します。このワークフローは、テスト実行前に前回のスナップショットをダウンロードし、その後で更新済みのファイルをアップロードします。'--report-gh' が必要です。</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">フレーク テストのコンテキストに使用するために保持するテスト履歴の日数 (1 - 90)。既定値は 30 です。'--report-gh-history' が必要です。</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">フレーク テストのコンテキストに使用するために保持するテスト履歴の日数 (1 - 90)。既定値は 30 です。'--report-gh-history' が必要です。</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
-        <target state="translated">'--report-gh-history-window' オプションを使用するには、'--report-gh-history' を指定する必要があります。</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">'--report-gh-history-window' オプションを使用するには、'--report-gh-history' を指定する必要があります。</target>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">GitHub Actions ジョブの要約セクション '{0}' が無効です。有効な値は 'test-results'、'slow-tests'、'coverage'、または 'all' です。値は、繰り返し、スペース区切り、またはコンマ区切りにできます。</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">GitHub Actions ジョブの要約セクション '{0}' が無効です。有効な値は 'test-results'、'slow-tests'、'coverage'、または 'all' です。値は、繰り返し、スペース区切り、またはコンマ区切りにできます。</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">値 '{0}' が無効です。有効な値は、'on' (または 'true'、'enable'、'1') または 'off' (または 'false'、'disable'、'0')、あるいは 'on-failure' です。</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">値 '{0}' が無効です。有効な値は、'on' (または 'true'、'enable'、'1') または 'off' (または 'false'、'disable'、'0')、あるいは 'on-failure' です。</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -289,13 +289,13 @@
       </trans-unit>
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">GITHUB_STEP_SUMMARY ファイルへのマークダウン ジョブの要約の書き込みを制御します。有効な値は、'on' ('true'、'enable'、'1' も指定可能)、'off' ('false'、'disable'、'0' も指定可能)、またはテストの呼び出しが失敗した場合のみ書き込む 'on-failure' です。GitHub Actions で実行する場合、既定値は 'on' です。</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <target state="needs-review-translation">GITHUB_STEP_SUMMARY ファイルへのマークダウン ジョブの要約の書き込みを制御します。有効な値は、'on' ('true'、'enable'、'1' も指定可能)、'off' ('false'、'disable'、'0' も指定可能)、またはテストの呼び出しが失敗した場合のみ書き込む 'on-failure' です。GitHub Actions で実行する場合、既定値は 'on' です。</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">GitHub Actions ジョブの要約に含めるコンテンツを選択します。'test-results'、'slow-tests'、'coverage'、または 'all' の値を、繰り返し、スペース区切り、またはコンマ区切りで 1 つ以上指定してください。既定値は 'all' です。'--report-gh' が必要です。</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">GitHub Actions ジョブの要約に含めるコンテンツを選択します。'test-results'、'slow-tests'、'coverage'、または 'all' の値を、繰り返し、スペース区切り、またはコンマ区切りで 1 つ以上指定してください。既定値は 'all' です。'--report-gh' が必要です。</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">GitHub Actions レポートのサブオプションでは、'--{0}' を指定する必要があります。</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">GitHub Actions レポートのサブオプションでは、'--{0}' を指定する必要があります。</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ko.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">하나 이상의 GitHub Actions 작업 요약 섹션이 필요합니다. 유효한 값은 'test-results', 'slow-tests', 'coverage' 또는 'all'입니다.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">하나 이상의 GitHub Actions 작업 요약 섹션이 필요합니다. 유효한 값은 'test-results', 'slow-tests', 'coverage' 또는 'all'입니다.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">작업 요약에서 실패한 각 테스트를 실패 메시지, 예외 유형, 원본 위치 및 스택 추적이 포함된 접을 수 있는 섹션으로 확장할지 여부를 설정합니다. 유효한 값은 'on'('true', 'enable', '1'도 허용) 또는 'off'('false', 'disable', '0'도 허용)입니다. GitHub Actions에서 실행할 때 기본값은 'on'입니다.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">작업 요약에서 실패한 각 테스트를 실패 메시지, 예외 유형, 원본 위치 및 스택 추적이 포함된 접을 수 있는 섹션으로 확장할지 여부를 설정합니다. 유효한 값은 'on'('true', 'enable', '1'도 허용) 또는 'off'('false', 'disable', '0'도 허용)입니다. GitHub Actions에서 실행할 때 기본값은 'on'입니다.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">지정된 경로에서 바인딩된 GitHub Actions 테스트 기록 스냅샷을 읽고 업데이트합니다. 워크플로는 테스트 실행 전에 이전 스냅샷을 다운로드하고 나중에 업데이트된 파일을 업로드합니다. '--report-gh'가 필요합니다.</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">지정된 경로에서 바인딩된 GitHub Actions 테스트 기록 스냅샷을 읽고 업데이트합니다. 워크플로는 테스트 실행 전에 이전 스냅샷을 다운로드하고 나중에 업데이트된 파일을 업로드합니다. '--report-gh'가 필요합니다.</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">불안정한 테스트 컨텍스트에 보존하고 사용할 테스트 기록의 일 수입니다(1-90). 기본값은 30입니다. '--report-gh-history'가 필요합니다.</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">불안정한 테스트 컨텍스트에 보존하고 사용할 테스트 기록의 일 수입니다(1-90). 기본값은 30입니다. '--report-gh-history'가 필요합니다.</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
-        <target state="translated">'--report-gh-history-window' 옵션을 사용하려면 '--report-gh-history'를 지정해야 합니다.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">'--report-gh-history-window' 옵션을 사용하려면 '--report-gh-history'를 지정해야 합니다.</target>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">잘못된 GitHub Actions 작업 요약 섹션 '{0}'입니다. 유효한 값은 'test-results', 'slow-tests', 'coverage' 또는 'all'입니다. 값은 반복되거나 공백이나 쉼표로 구분할 수 있습니다.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">잘못된 GitHub Actions 작업 요약 섹션 '{0}'입니다. 유효한 값은 'test-results', 'slow-tests', 'coverage' 또는 'all'입니다. 값은 반복되거나 공백이나 쉼표로 구분할 수 있습니다.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">값 '{0}'이(가) 잘못되었습니다. 유효한 값은 'on'(또는 'true', 'enable', '1'), 'off'(또는 'false', 'disable', '0') 또는 'on-failure'입니다.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">값 '{0}'이(가) 잘못되었습니다. 유효한 값은 'on'(또는 'true', 'enable', '1'), 'off'(또는 'false', 'disable', '0') 또는 'on-failure'입니다.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -289,13 +289,13 @@
       </trans-unit>
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">GITHUB_STEP_SUMMARY 파일에 markdown 작업 요약을 작성하는 것을 제어합니다. 유효한 값은 'on'('true', 'enable', '1'도 허용), 'off'('false', 'disable', '0'도 허용) 또는 테스트 호출이 실패할 때만 작성하는 'on-failure'입니다. GitHub Actions에서 실행할 때 기본값은 'on'입니다.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <target state="needs-review-translation">GITHUB_STEP_SUMMARY 파일에 markdown 작업 요약을 작성하는 것을 제어합니다. 유효한 값은 'on'('true', 'enable', '1'도 허용), 'off'('false', 'disable', '0'도 허용) 또는 테스트 호출이 실패할 때만 작성하는 'on-failure'입니다. GitHub Actions에서 실행할 때 기본값은 'on'입니다.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">GitHub Actions 작업 요약에 포함된 콘텐츠를 선택합니다. 'test-results', 'slow-tests', 'coverage' 또는 'all' 값을 하나 이상 지정하세요. 값은 반복되거나 공백이나 쉼표로 구분할 수 있습니다. 기본값은 'all'입니다. '--report-gh'가 필요합니다.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">GitHub Actions 작업 요약에 포함된 콘텐츠를 선택합니다. 'test-results', 'slow-tests', 'coverage' 또는 'all' 값을 하나 이상 지정하세요. 값은 반복되거나 공백이나 쉼표로 구분할 수 있습니다. 기본값은 'all'입니다. '--report-gh'가 필요합니다.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">GitHub Actions 보고서 하위 옵션을 사용하려면 '--{0}'을(를) 지정해야 합니다.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">GitHub Actions 보고서 하위 옵션을 사용하려면 '--{0}'을(를) 지정해야 합니다.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.pl.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">Wymagana jest co najmniej jedna sekcja podsumowania zadania funkcji GitHub Actions. Prawidłowe wartości to „test-results”, „slow-tests”, „coverage” lub „all”.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Wymagana jest co najmniej jedna sekcja podsumowania zadania funkcji GitHub Actions. Prawidłowe wartości to „test-results”, „slow-tests”, „coverage” lub „all”.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Włącz lub wyłącz opcję rozwijania każdego nieudanego testu w podsumowaniu zadania do sekcji, którą można zwinąć, zawierającej komunikat o niepowodzeniu, typ wyjątku, lokalizację źródłową oraz ślad stosu. Dopuszczalne wartości to 'on' (akceptowane są również wartości 'true', 'enable', '1') lub 'off' (akceptowane są również wartości 'false', 'disable', '0'). Wartość domyślna to 'on' podczas uruchamiania w funkcji GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">Włącz lub wyłącz opcję rozwijania każdego nieudanego testu w podsumowaniu zadania do sekcji, którą można zwinąć, zawierającej komunikat o niepowodzeniu, typ wyjątku, lokalizację źródłową oraz ślad stosu. Dopuszczalne wartości to 'on' (akceptowane są również wartości 'true', 'enable', '1') lub 'off' (akceptowane są również wartości 'false', 'disable', '0'). Wartość domyślna to 'on' podczas uruchamiania w funkcji GitHub Actions.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Odczytaj i zaktualizuj powiązaną migawkę historii testów funkcji GitHub Actions w określonej ścieżce. Przepływ pracy odpowiada za pobranie poprzedniej migawki przed uruchomieniem testów i przekazanie zaktualizowanego pliku po jego zakończeniu. Wymaga elementu „--report-gh”.</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Odczytaj i zaktualizuj powiązaną migawkę historii testów funkcji GitHub Actions w określonej ścieżce. Przepływ pracy odpowiada za pobranie poprzedniej migawki przed uruchomieniem testów i przekazanie zaktualizowanego pliku po jego zakończeniu. Wymaga elementu „--report-gh”.</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Liczba dni historii testów do zachowania i użycia do kontekstu dla niestabilnych testów (1–90). Wartość domyślna to 30. Wymaga elementu „--report-gh-history”.</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Liczba dni historii testów do zachowania i użycia do kontekstu dla niestabilnych testów (1–90). Wartość domyślna to 30. Wymaga elementu „--report-gh-history”.</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
         <target state="new">The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">Nieprawidłowa sekcja podsumowania zadania funkcji GitHub Actions „{0}”. Prawidłowe wartości to „test-results”, „slow-tests”, „coverage” lub „all”. Wartości można powtarzać, rozdzielać spacjami lub przecinkami.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Nieprawidłowa sekcja podsumowania zadania funkcji GitHub Actions „{0}”. Prawidłowe wartości to „test-results”, „slow-tests”, „coverage” lub „all”. Wartości można powtarzać, rozdzielać spacjami lub przecinkami.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
         <target state="new">Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -290,12 +290,12 @@
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">Wybierz zawartość zawartą w podsumowaniu zadania funkcji GitHub Actions. Określ jedną lub więcej wartości, powtórz je albo rozdziel spacjami lub przecinkami: „test-results”, „slow-tests”, „coverage” lub „all”. Wartość domyślna to „all”. Wymaga elementu „--report-gh”.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Wybierz zawartość zawartą w podsumowaniu zadania funkcji GitHub Actions. Określ jedną lub więcej wartości, powtórz je albo rozdziel spacjami lub przecinkami: „test-results”, „slow-tests”, „coverage” lub „all”. Wartość domyślna to „all”. Wymaga elementu „--report-gh”.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">Opcje podrzędne raportu funkcji GitHub Actions wymagają określenia parametru „--{0}”.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">Opcje podrzędne raportu funkcji GitHub Actions wymagają określenia parametru „--{0}”.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.pt-BR.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">É necessária pelo menos uma seção de resumo de trabalho do GitHub Actions. Os valores válidos são 'test-results', 'slow-tests', 'coverage' ou 'all'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">É necessária pelo menos uma seção de resumo de trabalho do GitHub Actions. Os valores válidos são 'test-results', 'slow-tests', 'coverage' ou 'all'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Habilite ou desabilite a expansão de cada teste com falha no resumo do trabalho em uma seção recolhível com sua mensagem de falha, tipo de exceção, localização de origem e rastreamento de pilha. Os valores válidos são 'on' (também aceita 'true', 'enable', '1') ou 'off' (também aceita 'false', 'disable', '0'). O padrão é 'on' durante a execução no GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">Habilite ou desabilite a expansão de cada teste com falha no resumo do trabalho em uma seção recolhível com sua mensagem de falha, tipo de exceção, localização de origem e rastreamento de pilha. Os valores válidos são 'on' (também aceita 'true', 'enable', '1') ou 'off' (também aceita 'false', 'disable', '0'). O padrão é 'on' durante a execução no GitHub Actions.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Ler e atualizar um instantâneo limitado do histórico de testes do GitHub Actions no caminho especificado. O fluxo de trabalho é responsável por baixar o instantâneo anterior antes da execução do teste e enviar o arquivo atualizado depois. Requer '--report-gh'.</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Ler e atualizar um instantâneo limitado do histórico de testes do GitHub Actions no caminho especificado. O fluxo de trabalho é responsável por baixar o instantâneo anterior antes da execução do teste e enviar o arquivo atualizado depois. Requer '--report-gh'.</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Número de dias do histórico de testes a serem mantidos e usados no contexto de testes instáveis (1 a 90). O padrão é 30. Requer '--report-gh-history'.</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Número de dias do histórico de testes a serem mantidos e usados no contexto de testes instáveis (1 a 90). O padrão é 30. Requer '--report-gh-history'.</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
-        <target state="translated">A opção '--report-gh-history-window' exige que '--report-gh-history' seja especificado.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">A opção '--report-gh-history-window' exige que '--report-gh-history' seja especificado.</target>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">Seção de resumo de trabalho do GitHub Actions inválida: '{0}'. Os valores válidos são 'test-results', 'slow-tests', 'coverage' ou 'all'. Os valores podem ser repetidos, separados por espaços ou por vírgulas.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Seção de resumo de trabalho do GitHub Actions inválida: '{0}'. Os valores válidos são 'test-results', 'slow-tests', 'coverage' ou 'all'. Os valores podem ser repetidos, separados por espaços ou por vírgulas.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">Valor inválido: '{0}'. Os valores válidos são 'on' (ou 'true', 'enable', '1'), 'off' (ou 'false', 'disable', '0') ou 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">Valor inválido: '{0}'. Os valores válidos são 'on' (ou 'true', 'enable', '1'), 'off' (ou 'false', 'disable', '0') ou 'on-failure'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -289,13 +289,13 @@
       </trans-unit>
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">Controla a gravação de um resumo do trabalho em Markdown no arquivo GITHUB_STEP_SUMMARY. Os valores válidos são 'on' (também aceita 'true', 'enable', '1'), 'off' (também aceita 'false', 'disable', '0') ou 'on-failure' para gravar somente quando a invocação de teste falhar. O padrão é 'on' ao executar no GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <target state="needs-review-translation">Controla a gravação de um resumo do trabalho em Markdown no arquivo GITHUB_STEP_SUMMARY. Os valores válidos são 'on' (também aceita 'true', 'enable', '1'), 'off' (também aceita 'false', 'disable', '0') ou 'on-failure' para gravar somente quando a invocação de teste falhar. O padrão é 'on' ao executar no GitHub Actions.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">Selecione o conteúdo incluído no resumo do trabalho do GitHub Actions. Especifique um ou mais valores, repetidos, separados por espaços ou por vírgulas: 'test-results', 'slow-tests', 'coverage' ou 'all'. O padrão é 'all'. Requer '--report-gh'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Selecione o conteúdo incluído no resumo do trabalho do GitHub Actions. Especifique um ou mais valores, repetidos, separados por espaços ou por vírgulas: 'test-results', 'slow-tests', 'coverage' ou 'all'. O padrão é 'all'. Requer '--report-gh'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">As subopções de relatório do GitHub Actions exigem que '--{0}' seja especificado.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">As subopções de relatório do GitHub Actions exigem que '--{0}' seja especificado.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">Требуется по крайней мере один раздел сводки действий GitHub. Допустимые значения: 'test-results', 'slow-tests', 'coverage' или 'all'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Требуется по крайней мере один раздел сводки действий GitHub. Допустимые значения: 'test-results', 'slow-tests', 'coverage' или 'all'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -140,7 +140,7 @@
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Читает и обновляет ограниченный снимок журнала тестов GitHub Actions по указанному пути. Рабочий процесс отвечает за скачивание предыдущего снимка перед запуском теста и за отправку обновленного файла после его завершения. Требуется "--report-gh".</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Читает и обновляет ограниченный снимок журнала тестов GitHub Actions по указанному пути. Рабочий процесс отвечает за скачивание предыдущего снимка перед запуском теста и за отправку обновленного файла после его завершения. Требуется "--report-gh".</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Число дней журнала тестов, которые нужно сохранять и использовать в качестве контекста для нестабильных тестов (1–90). По умолчанию 30. Требует "--report-gh-history".</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Число дней журнала тестов, которые нужно сохранять и использовать в качестве контекста для нестабильных тестов (1–90). По умолчанию 30. Требует "--report-gh-history".</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
         <target state="new">The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">Недопустимый раздел сводки задания GitHub Actions '{0}'. Допустимые значения: 'test-results', 'slow-tests', 'coverage' или 'all'. Значения могут повторяться, разделяться пробелами или запятыми.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Недопустимый раздел сводки задания GitHub Actions '{0}'. Допустимые значения: 'test-results', 'slow-tests', 'coverage' или 'all'. Значения могут повторяться, разделяться пробелами или запятыми.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">Недопустимое значение '{0}'. Допустимые значения: 'on' (или 'true', 'enable', '1'), 'off' (или 'false', 'disable', '0') или 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">Недопустимое значение '{0}'. Допустимые значения: 'on' (или 'true', 'enable', '1'), 'off' (или 'false', 'disable', '0') или 'on-failure'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -290,12 +290,12 @@
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">Выберите содержимое, включенное в сводку задания действий GitHub. Укажите одно или несколько значений, повторяющихся, разделенных пробелами или запятыми: 'test-results', 'slow-tests', 'coverage' или 'all'. Значение по умолчанию: 'all'. Требуется '--report-gh'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Выберите содержимое, включенное в сводку задания действий GitHub. Укажите одно или несколько значений, повторяющихся, разделенных пробелами или запятыми: 'test-results', 'slow-tests', 'coverage' или 'all'. Значение по умолчанию: 'all'. Требуется '--report-gh'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">Для подпараметров отчета GitHub Actions необходимо указать '--{0}'.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">Для подпараметров отчета GitHub Actions необходимо указать '--{0}'.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.tr.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">En az bir GitHub Actions iş özeti bölümü gereklidir. Geçerli değerler: 'test-results', 'slow-tests', 'coverage' veya 'all'.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">En az bir GitHub Actions iş özeti bölümü gereklidir. Geçerli değerler: 'test-results', 'slow-tests', 'coverage' veya 'all'.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">İş özetindeki her başarısız testi hata iletisi, özel durum türü, kaynak konumu ve yığın izlemesiyle birlikte daraltılabilen bir bölüme genişletmeyi etkinleştirin veya devre dışı bırakın. Geçerli değerler: 'on' ('true', 'enable', '1' değerlerini de kabul eder) ve 'off' ('false', 'disable', '0' değerlerini de kabul eder). GitHub Actions üzerinde çalışırken varsayılan değer 'on' olur.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">İş özetindeki her başarısız testi hata iletisi, özel durum türü, kaynak konumu ve yığın izlemesiyle birlikte daraltılabilen bir bölüme genişletmeyi etkinleştirin veya devre dışı bırakın. Geçerli değerler: 'on' ('true', 'enable', '1' değerlerini de kabul eder) ve 'off' ('false', 'disable', '0' değerlerini de kabul eder). GitHub Actions üzerinde çalışırken varsayılan değer 'on' olur.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">Belirtilen yoldaki sınırlanmış GitHub Actions test geçmişi anlık görüntüsünü okuyun ve güncelleştirin. İş akışı, test çalıştırılmadan önce geçmiş anlık görüntüyü indirmekten ve ardından güncelleştirilmiş dosyayı karşıya yüklemekten sorumludur. '--report-gh' gerektirir.</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">Belirtilen yoldaki sınırlanmış GitHub Actions test geçmişi anlık görüntüsünü okuyun ve güncelleştirin. İş akışı, test çalıştırılmadan önce geçmiş anlık görüntüyü indirmekten ve ardından güncelleştirilmiş dosyayı karşıya yüklemekten sorumludur. '--report-gh' gerektirir.</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">Kararsız test bağlamı için saklanacak ve kullanılacak test geçmişi gün sayısı (1-90). Varsayılan değer 30'dur. '--report-gh-history' gerektirir.</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">Kararsız test bağlamı için saklanacak ve kullanılacak test geçmişi gün sayısı (1-90). Varsayılan değer 30'dur. '--report-gh-history' gerektirir.</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
-        <target state="translated">'--report-gh-history-window' seçeneği için '--report-gh-history' belirtilmelidir.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">'--report-gh-history-window' seçeneği için '--report-gh-history' belirtilmelidir.</target>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">Geçersiz GitHub Actions iş özeti bölümü “{0}”. Geçerli değerler: 'test-results', 'slow-tests', 'coverage' veya 'all'. Değerler yinelenebilir, boşlukla ayrılmış veya virgülle ayrılmış olabilir.</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">Geçersiz GitHub Actions iş özeti bölümü “{0}”. Geçerli değerler: 'test-results', 'slow-tests', 'coverage' veya 'all'. Değerler yinelenebilir, boşlukla ayrılmış veya virgülle ayrılmış olabilir.</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">Geçersiz değer '{0}'. Geçerli değerler: 'on' (veya 'true', 'enable', '1'), 'off' (veya 'false', 'disable', '0') ya da 'on-failure'.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">Geçersiz değer '{0}'. Geçerli değerler: 'on' (veya 'true', 'enable', '1'), 'off' (veya 'false', 'disable', '0') ya da 'on-failure'.</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -290,12 +290,12 @@
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">GitHub Actions iş özetine eklenecek içeriği seçin. Bir veya daha fazla değer belirtin; yinelenebilir, boşlukla ayrılmış veya virgülle ayrılmış olabilir: 'test-results', 'slow-tests', 'coverage' veya 'all'. Varsayılan değer 'all' olur. '--report-gh' gerektirir.</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">GitHub Actions iş özetine eklenecek içeriği seçin. Bir veya daha fazla değer belirtin; yinelenebilir, boşlukla ayrılmış veya virgülle ayrılmış olabilir: 'test-results', 'slow-tests', 'coverage' veya 'all'. Varsayılan değer 'all' olur. '--report-gh' gerektirir.</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">GitHub Actions raporunun alt seçenekleri için '--{0}' belirtilmelidir.</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">GitHub Actions raporunun alt seçenekleri için '--{0}' belirtilmelidir.</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.zh-Hans.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">至少需要一个 GitHub Actions 作业摘要部分。有效值为 'test-results'、'slow-tests'、'coverage' 或 'all'。</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">至少需要一个 GitHub Actions 作业摘要部分。有效值为 'test-results'、'slow-tests'、'coverage' 或 'all'。</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">启用或禁用会将作业摘要中每个失败的测试扩展为可折叠部分，并在其中包含失败消息、异常类型、源位置和堆栈跟踪。有效值为 'on' (还支持 'true'、'enable'、'1')或 'off' (还支持 'false'、'disable'、'0')。在 GitHub Actions 上运行时，默认值为 'on'。</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">启用或禁用会将作业摘要中每个失败的测试扩展为可折叠部分，并在其中包含失败消息、异常类型、源位置和堆栈跟踪。有效值为 'on' (还支持 'true'、'enable'、'1')或 'off' (还支持 'false'、'disable'、'0')。在 GitHub Actions 上运行时，默认值为 'on'。</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">读取并更新指定路径下的有界 GitHub Actions 测试历史记录快照。工作流负责在测试运行前下载先前的快照，并在之后上传更新后的文件。需要 "--report-gh"。</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">读取并更新指定路径下的有界 GitHub Actions 测试历史记录快照。工作流负责在测试运行前下载先前的快照，并在之后上传更新后的文件。需要 "--report-gh"。</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">要保留并用于不稳定测试上下文的测试历史天数(1-90)。默认为 30。需要 "--report-gh-history"。</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">要保留并用于不稳定测试上下文的测试历史天数(1-90)。默认为 30。需要 "--report-gh-history"。</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
         <target state="new">The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">GitHub Actions 作业摘要部分“{0}”无效。有效值为 'test-results'、'slow-tests'、'coverage' 或 'all'。值可以重复、用空格分隔或用逗号分隔。</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">GitHub Actions 作业摘要部分“{0}”无效。有效值为 'test-results'、'slow-tests'、'coverage' 或 'all'。值可以重复、用空格分隔或用逗号分隔。</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">值“{0}”无效。有效值为 'on' (或 'true'、'enable'、'1')、'off' (或 'false'、'disable'、'0') 或 'on-failure'。</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">值“{0}”无效。有效值为 'on' (或 'true'、'enable'、'1')、'off' (或 'false'、'disable'、'0') 或 'on-failure'。</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -290,12 +290,12 @@
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
         <target state="new">Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">选择要包含在 GitHub Actions 作业摘要中的内容。指定一个或多个值，可重复、用空格分隔或用逗号分隔: 'test-results'、'slow-tests'、'coverage' 或 'all'。默认为 'all'。需要 '--report-gh'。</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">选择要包含在 GitHub Actions 作业摘要中的内容。指定一个或多个值，可重复、用空格分隔或用逗号分隔: 'test-results'、'slow-tests'、'coverage' 或 'all'。默认为 'all'。需要 '--report-gh'。</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">GitHub Actions 报告子选项需要指定 "--{0}"。</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">GitHub Actions 报告子选项需要指定 "--{0}"。</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.zh-Hant.xlf
@@ -24,8 +24,8 @@
       </trans-unit>
       <trans-unit id="EmptyStepSummarySections">
         <source>At least one GitHub Actions job-summary section is required. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'.</source>
-        <target state="translated">至少需要一個 GitHub Actions 作業摘要區段。有效值為 'test-results'、'slow-tests'、'coverage' 或 'all'。</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">至少需要一個 GitHub Actions 作業摘要區段。有效值為 'test-results'、'slow-tests'、'coverage' 或 'all'。</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="ExitCodeAnnotationTitle">
         <source>Test run failed (exit code {0}: {1})</source>
@@ -139,8 +139,8 @@
       </trans-unit>
       <trans-unit id="FailureDetailsOptionDescription">
         <source>Enable or disable expanding each failed test in the job summary into a collapsible section with its failure message, exception type, source location and stack trace. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">啟用或停用將工作摘要中的每個失敗測試展開為可摺疊區段，並顯示其失敗訊息、例外狀況類型、來源位置和堆疊追蹤。有效值為 'on' (也接受 'true'、'enable'、'1') 或 'off' (也接受 'false'、'disable'、'0')。在 GitHub Actions 上執行時，預設為 'on'。</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}</note>
+        <target state="needs-review-translation">啟用或停用將工作摘要中的每個失敗測試展開為可摺疊區段，並顯示其失敗訊息、例外狀況類型、來源位置和堆疊追蹤。有效值為 'on' (也接受 'true'、'enable'、'1') 或 'off' (也接受 'false'、'disable'、'0')。在 GitHub Actions 上執行時，預設為 'on'。</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="'disable'"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="FailureListTruncated">
         <source>Showing the first {0} of {1} failed tests. See the workflow log or the test report for the remaining failures.</source>
@@ -179,8 +179,8 @@
       </trans-unit>
       <trans-unit id="HistoryOptionDescription">
         <source>Read and update a bounded GitHub Actions test history snapshot at the specified path. The workflow is responsible for downloading the prior snapshot before the test run and uploading the updated file afterward. Requires '--report-gh'.</source>
-        <target state="translated">讀取並更新位於指定路徑的 GitHub Actions 測試歷程記錄快照。此工作流程負責在測試執行前下載先前的快照，並在執行後上傳更新後的檔案。需要 '--report-gh'。</target>
-        <note>{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">讀取並更新位於指定路徑的 GitHub Actions 測試歷程記錄快照。此工作流程負責在測試執行前下載先前的快照，並在執行後上傳更新後的檔案。需要 '--report-gh'。</target>
+        <note>{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="HistoryRegressionContext">
         <source>Historical context: passed all {0} prior runs within the {1}-day history window.</source>
@@ -189,13 +189,13 @@
       </trans-unit>
       <trans-unit id="HistoryWindowOptionDescription">
         <source>Number of days of test history to retain and use for flaky-test context (1-90). Defaults to 30. Requires '--report-gh-history'.</source>
-        <target state="translated">要保留並用於不穩定測試內容的測試歷程記錄天數 (1-90)。預設為 30。需要 '--report-gh-history'。</target>
-        <note>{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">要保留並用於不穩定測試內容的測試歷程記錄天數 (1-90)。預設為 30。需要 '--report-gh-history'。</target>
+        <note>{Locked="--report-gh-history"}</note>
       </trans-unit>
       <trans-unit id="HistoryWindowRequiresHistory">
         <source>The '--report-gh-history-window' option requires '--report-gh-history' to be specified.</source>
-        <target state="translated">'--report-gh-history-window' 選項需要指定 '--report-gh-history'。</target>
-        <note>{Locked="'--report-gh-history-window'"}{Locked="'--report-gh-history'"}</note>
+        <target state="needs-review-translation">'--report-gh-history-window' 選項需要指定 '--report-gh-history'。</target>
+        <note>{Locked="--report-gh-history-window"}{Locked="'--report-gh-history'"}</note>
       </trans-unit>
       <trans-unit id="HistoryWriteFailedWarning">
         <source>Failed to write the GitHub Actions test history snapshot to '{0}': {1}</source>
@@ -224,13 +224,13 @@
       </trans-unit>
       <trans-unit id="InvalidStepSummarySection">
         <source>Invalid GitHub Actions job-summary section '{0}'. Valid values are 'test-results', 'slow-tests', 'coverage', or 'all'. Values can be repeated, space-separated, or comma-separated.</source>
-        <target state="translated">GitHub Actions 作業摘要區段 '{0}' 無效。有效值為 'test-results'、'slow-tests'、'coverage' 或 'all'。值可以重複，並以空格或逗號分隔。</target>
-        <note>{0} is the invalid section name. {Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}</note>
+        <target state="needs-review-translation">GitHub Actions 作業摘要區段 '{0}' 無效。有效值為 'test-results'、'slow-tests'、'coverage' 或 'all'。值可以重複，並以空格或逗號分隔。</target>
+        <note>{0} is the invalid section name. {Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}</note>
       </trans-unit>
       <trans-unit id="InvalidStepSummaryValue">
         <source>Invalid value '{0}'. Valid values are 'on' (or 'true', 'enable', '1'), 'off' (or 'false', 'disable', '0'), or 'on-failure'.</source>
-        <target state="translated">'{0}' 值無效。有效值為 'on' (或 'true'、'enable'、'1') 或 'off' (或 'false'、'disable'、'0') 或 'on-failure'。</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{0} is the invalid value.</note>
+        <target state="needs-review-translation">'{0}' 值無效。有效值為 'on' (或 'true'、'enable'、'1') 或 'off' (或 'false'、'disable'、'0') 或 'on-failure'。</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="'0'"}{Locked="on-failure"}{0} is the invalid value.</note>
       </trans-unit>
       <trans-unit id="ModuleDetailsOmitted">
         <source>Failure details were omitted for {0} of {1} test project(s) because the error details already take up too much space. See the workflow log or the test report for their full diagnostics.</source>
@@ -289,13 +289,13 @@
       </trans-unit>
       <trans-unit id="StepSummaryOptionDescription">
         <source>Control writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1'), 'off' (also accepts 'false', 'disable', '0'), or 'on-failure' to write only when the test invocation fails. Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="translated">控制將 Markdown 工作摘要寫入至 GITHUB_STEP_SUMMARY 檔案。有效值為 'on' (也接受 'true'、'enable'、'1')、'off' (也接受 'false'、'disable'、'0')，或 'on-failure'，僅在測試叫用失敗時寫入。在 GitHub Actions 上執行時，預設為 'on'。</target>
-        <note>{Locked="'on'"}{Locked="'off'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="'on-failure'"}{Locked="GITHUB_STEP_SUMMARY"}</note>
+        <target state="needs-review-translation">控制將 Markdown 工作摘要寫入至 GITHUB_STEP_SUMMARY 檔案。有效值為 'on' (也接受 'true'、'enable'、'1')、'off' (也接受 'false'、'disable'、'0')，或 'on-failure'，僅在測試叫用失敗時寫入。在 GitHub Actions 上執行時，預設為 'on'。</target>
+        <note>{Locked="'on'"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="on-failure"}{Locked="GITHUB_STEP_SUMMARY"}</note>
       </trans-unit>
       <trans-unit id="StepSummarySectionsOptionDescription">
         <source>Select the content included in the GitHub Actions job summary. Specify one or more values, repeated, space-separated, or comma-separated: 'test-results', 'slow-tests', 'coverage', or 'all'. Defaults to 'all'. Requires '--report-gh'.</source>
-        <target state="translated">選取要包含在 GitHub Actions 作業摘要中的內容。請指定一或多個值，可重複，並以空格或逗號分隔：'test-results'、'slow-tests'、'coverage' 或 'all'。預設為 'all'。需要 '--report-gh'。</target>
-        <note>{Locked="'test-results'"}{Locked="'slow-tests'"}{Locked="'coverage'"}{Locked="'all'"}{Locked="'--report-gh'"}</note>
+        <target state="needs-review-translation">選取要包含在 GitHub Actions 作業摘要中的內容。請指定一或多個值，可重複，並以空格或逗號分隔：'test-results'、'slow-tests'、'coverage' 或 'all'。預設為 'all'。需要 '--report-gh'。</target>
+        <note>{Locked="test-results"}{Locked="slow-tests"}{Locked="coverage"}{Locked="all"}{Locked="--report-gh"}</note>
       </trans-unit>
       <trans-unit id="StepSummaryWriteFailedWarning">
         <source>Failed to write the GitHub Actions job summary to '{0}': {1}</source>
@@ -304,8 +304,8 @@
       </trans-unit>
       <trans-unit id="SubOptionsRequireReportGh">
         <source>The GitHub Actions report sub-options require '--{0}' to be specified.</source>
-        <target state="translated">GitHub Actions 報告子選項需要指定 '--{0}'。</target>
-        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="'--{0}'"}</note>
+        <target state="needs-review-translation">GitHub Actions 報告子選項需要指定 '--{0}'。</target>
+        <note>Validation error when a sub-option is used without the report option. {0} is the report option name. {Locked="--{0}"}</note>
       </trans-unit>
       <trans-unit id="SummaryCondensed">
         <source>condensed to one line because the summary already takes up too much space. See the workflow log or the test report for full results.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/ExtensionResources.resx
@@ -110,7 +110,7 @@
     <value>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</value>
-    <comment>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</comment>
+    <comment>Do not localize format name {Locked=&quot;HTML&quot;}, placeholder tokens {Locked=&quot;{pname}&quot;}{Locked=&quot;{pid}&quot;}{Locked=&quot;{asm}&quot;}{Locked=&quot;{tfm}&quot;}{Locked=&quot;{arch}&quot;}{Locked=&quot;{time}&quot;}, file extension {Locked=&quot;.html&quot;}, or example file name {Locked=&quot;MyReport_{tfm}.html&quot;}.</comment>
   </data>
   <data name="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory" xml:space="preserve">
     <value>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</value>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">Název vygenerované sestavy HTML. Může obsahovat relativní nebo absolutní cestu. Relativní cesty se překládají na adresář výsledků testů a vytvoří se chybějící adresáře.
+        <target state="needs-review-translation">Název vygenerované sestavy HTML. Může obsahovat relativní nebo absolutní cestu. Relativní cesty se překládají na adresář výsledků testů a vytvoří se chybějící adresáře.
 Podporuje následující zástupné symboly: {pname} (název testovací aplikace), {pid} (ID procesu), {asm} (název sestavení položky), {tfm} (moniker cílové architektury), {arch} (architektura procesu), {time} (časové razítko).
 Příklad: MyReport_{tfm}.html.</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.de.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">Der Name des generierten HTML-Berichts. Kann einen relativen oder absoluten Pfad enthalten. Relative Pfade werden anhand des Verzeichnisses mit den Testergebnissen aufgelöst, und fehlende Verzeichnisse werden erstellt.
+        <target state="needs-review-translation">Der Name des generierten HTML-Berichts. Kann einen relativen oder absoluten Pfad enthalten. Relative Pfade werden anhand des Verzeichnisses mit den Testergebnissen aufgelöst, und fehlende Verzeichnisse werden erstellt.
 Unterstützt die folgenden Platzhalter: {pname} (Name der Testanwendung), {pid} (Prozess-ID), {asm} (Name der Eintragsassembly), {tfm} (Zielframeworkmoniker), {arch} (Prozessorarchitektur), {time} (Zeitstempel).
 Beispiel: „MyReport_{tfm}.html“.</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.es.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">Nombre del informe HTML generado. Puede incluir una ruta de acceso relativa o absoluta; las rutas de acceso relativas se resuelven respecto al directorio de resultados de pruebas y se crean los directorios que falten.
+        <target state="needs-review-translation">Nombre del informe HTML generado. Puede incluir una ruta de acceso relativa o absoluta; las rutas de acceso relativas se resuelven respecto al directorio de resultados de pruebas y se crean los directorios que falten.
 Admite los siguientes marcadores de posición: {pname} (nombre de la aplicación de prueba), {pid} (id. de proceso), {asm} (nombre del ensamblado de entrada), {tfm} (moniker de la plataforma de destino), {arch} (arquitectura del proceso), {time} (marca de tiempo).
 Ejemplo: "MyReport_{tfm}.html".</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">Le nom du rapport HTML généré. Peut inclure un chemin d’accès relatif ou absolu. Les chemins relatifs sont résolus sur le répertoire des résultats des tests et les répertoires manquants sont créés.
+        <target state="needs-review-translation">Le nom du rapport HTML généré. Peut inclure un chemin d’accès relatif ou absolu. Les chemins relatifs sont résolus sur le répertoire des résultats des tests et les répertoires manquants sont créés.
 Permet de prendre en charge les espaces réservés suivants: {pname} (nom de l’application de test), {pid} (ID de processus), {asm} (nom de l’assembly d’entrée), {tfm} (moniker de framework cible), {arch} (architecture du processus), {time} (horodateur).
 Exemple : 'MyReport_{tfm}.html'.</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.it.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">Nome del report HTML generato. Può includere un percorso relativo o assoluto. I percorsi relativi vengono risolti rispetto alla directory dei risultati del test e le directory mancanti vengono create.
+        <target state="needs-review-translation">Nome del report HTML generato. Può includere un percorso relativo o assoluto. I percorsi relativi vengono risolti rispetto alla directory dei risultati del test e le directory mancanti vengono create.
 Supporta i seguenti segnaposto: {pname} (nome dell'applicazione di test), {pid} (ID processo), {asm} (nome dell'assembly di immissione), {tfm} (moniker framework di destinazione), {arch} (architettura processo), {time} (timestamp).
 Esempio: 'MyReport_{tfm}.html'.</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">生成された HTML レポートの名前。相対または絶対パスを含めることができます。相対パスはテスト結果ディレクトリを基準に解決され、存在しないディレクトリは作成されます。
+        <target state="needs-review-translation">生成された HTML レポートの名前。相対または絶対パスを含めることができます。相対パスはテスト結果ディレクトリを基準に解決され、存在しないディレクトリは作成されます。
 次のプレースホルダーがサポートされています: {pname} (テスト アプリケーション名)、{pid} (プロセス ID)、{asm} (エントリ アセンブリ名)、{tfm} (ターゲット フレームワーク モニカー)、{arch} (プロセス アーキテクチャ)、{time} (タイムスタンプ)。
 例: 'MyReport_{tfm}.html'。</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">생성된 HTML 보고서의 이름입니다. 상대 경로 또는 절대 경로를 사용할 수 있습니다. 상대 경로는 테스트 결과 디렉터리를 기준으로 확인되며, 없는 디렉터리는 만들어집니다.
+        <target state="needs-review-translation">생성된 HTML 보고서의 이름입니다. 상대 경로 또는 절대 경로를 사용할 수 있습니다. 상대 경로는 테스트 결과 디렉터리를 기준으로 확인되며, 없는 디렉터리는 만들어집니다.
 자리 표시자 {pname}(테스트 애플리케이션 이름), {pid}(프로세스 ID), {asm}(항목 어셈블리 이름), {tfm}(대상 프레임워크 모니커), {arch}(프로세스 아키텍처), {time}(타임스탬프)을(를) 지원합니다.
 예: 'MyReport_{tfm}.html'.</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">Nazwa wygenerowanego raportu HTML. Może zawierać ścieżkę względną lub bezwzględną; ścieżki względne są rozpoznawane względem katalogu wyników testów, a brakujące katalogi są tworzone.
+        <target state="needs-review-translation">Nazwa wygenerowanego raportu HTML. Może zawierać ścieżkę względną lub bezwzględną; ścieżki względne są rozpoznawane względem katalogu wyników testów, a brakujące katalogi są tworzone.
 Obsługuje następujące symbole zastępcze: {pname} (nazwa aplikacji testowej), {pid} (identyfikator procesu), {asm} (nazwa zestawu danych wejściowych), {tfm} (moniker platformy docelowej), {arch} (architektura procesu), {time} (sygnatura czasowa).
 Przykład: „MyReport_{tfm}.html”.</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">O nome do relatório HTML gerado. Pode incluir um caminho relativo ou absoluto; os caminhos relativos são resolvidos em relação ao diretório de resultados de teste, e os diretórios ausentes são criados.
+        <target state="needs-review-translation">O nome do relatório HTML gerado. Pode incluir um caminho relativo ou absoluto; os caminhos relativos são resolvidos em relação ao diretório de resultados de teste, e os diretórios ausentes são criados.
 Dá suporte aos seguintes espaços reservados: {pname} (nome do aplicativo de teste), {pid} (ID do processo), {asm} (nome do assembly de entrada), {tfm} (moniker da estrutura de destino), {arch} (arquitetura do processo), {time} (carimbo de data e hora).
 Exemplo: 'MyReport_{tfm}.html'.</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">Имя сгенерированного отчета в формате HTML. Может включать относительный или абсолютный путь; относительные пути разрешаются относительно каталога результатов тестов, а отсутствующие каталоги создаются.
+        <target state="needs-review-translation">Имя сгенерированного отчета в формате HTML. Может включать относительный или абсолютный путь; относительные пути разрешаются относительно каталога результатов тестов, а отсутствующие каталоги создаются.
 Поддерживает следующие заполнители: {pname} (имя тестового приложения), {pid} (идентификатор процесса), {asm} (имя входной сборки), {tfm} (моникер целевой платформы), {arch} (архитектура процесса), {time} (метка времени).
 Пример: "MyReport_{tfm}.html".</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">Oluşturulan HTML raporunun adı. Göreli veya mutlak yol içerebilir; göreli yollar test sonuçları dizinine göre çözülmüş ve eksik dizinler oluşturulur.
+        <target state="needs-review-translation">Oluşturulan HTML raporunun adı. Göreli veya mutlak yol içerebilir; göreli yollar test sonuçları dizinine göre çözülmüş ve eksik dizinler oluşturulur.
 Şu yer tutucuları destekler: {pname} (test uygulaması adı), {pid} (işlem kimliği), {asm} (girdi derleme adı), {tfm} (hedef çerçeve bilinen adı), {arch} (işlem mimarisi), {time} (zaman damgası).
 Örnek: 'MyReport_{tfm}.html'.</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">生成的 HTML 报表的名称。可以包含相对路径或绝对路径；相对路径针对测试结果目录进行解析，并创建缺少的目录。
+        <target state="needs-review-translation">生成的 HTML 报表的名称。可以包含相对路径或绝对路径；相对路径针对测试结果目录进行解析，并创建缺少的目录。
 支持以下占位符: {pname} (测试应用程序名称)、{pid} (进程 ID)、{asm} (入口程序集名称)、{tfm} (目标框架名字对象)、{arch} (进程体系结果)、{time} (时间戳)。
 示例: "MyReport_{tfm}.html"。</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -56,10 +56,10 @@
         <source>The name of the generated HTML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.html'.</source>
-        <target state="translated">產生的 HTML 報告名稱。可以包含相對或絕對路徑; 系統會針對測試結果目錄解析相對路徑，並建立遺漏的目錄。
+        <target state="needs-review-translation">產生的 HTML 報告名稱。可以包含相對或絕對路徑; 系統會針對測試結果目錄解析相對路徑，並建立遺漏的目錄。
 支援下列預留位置: {pname}(測試應用程式名稱)、{pid}(處理序識別碼)、{asm}(進入組件名稱)、{tfm}(目標 Framework Moniker)、{arch} (處理序結構)、{time}(時間戳記)。
 範例: 'MyReport_{tfm}.html'。</target>
-        <note>Do not localize option name {Locked="--report-html-filename"}, format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="'MyReport_{tfm}.html'"}.</note>
+        <note>Do not localize format name {Locked="HTML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".html"}, or example file name {Locked="MyReport_{tfm}.html"}.</note>
       </trans-unit>
       <trans-unit id="HtmlReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-html-filename' relative paths must stay under the test results directory (e.g. --report-html-filename nested/myreport.html)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/ExtensionResources.resx
@@ -169,7 +169,7 @@
     <value>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</value>
-    <comment>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</comment>
+    <comment>Do not localize format names {Locked=&quot;JUnit&quot;}{Locked=&quot;XML&quot;}, placeholder tokens {Locked=&quot;{pname}&quot;}{Locked=&quot;{pid}&quot;}{Locked=&quot;{asm}&quot;}{Locked=&quot;{tfm}&quot;}{Locked=&quot;{arch}&quot;}{Locked=&quot;{time}&quot;}, file extension {Locked=&quot;.xml&quot;}, or example file name {Locked=&quot;MyReport_{tfm}.xml&quot;}.</comment>
   </data>
   <data name="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory" xml:space="preserve">
     <value>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</value>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">Název vygenerované sestavy JUnit XML. Může obsahovat relativní nebo absolutní cestu. Relativní cesty se překládají na adresář výsledků testů a vytvoří se chybějící adresáře.
+        <target state="needs-review-translation">Název vygenerované sestavy JUnit XML. Může obsahovat relativní nebo absolutní cestu. Relativní cesty se překládají na adresář výsledků testů a vytvoří se chybějící adresáře.
 Podporuje následující zástupné symboly: {pname} (název testovací aplikace), {pid} (ID procesu), {asm} (název sestavení položky), {tfm} (moniker cílové architektury), {arch} (architektura procesu), {time} (časové razítko).
 Příklad: MyReport_{tfm}.xml.</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.de.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">Der Name des generierten JUnit XML-Berichts. Kann einen relativen oder absoluten Pfad enthalten. Relative Pfade werden anhand des Verzeichnisses mit den Testergebnissen aufgelöst, und fehlende Verzeichnisse werden erstellt.
+        <target state="needs-review-translation">Der Name des generierten JUnit XML-Berichts. Kann einen relativen oder absoluten Pfad enthalten. Relative Pfade werden anhand des Verzeichnisses mit den Testergebnissen aufgelöst, und fehlende Verzeichnisse werden erstellt.
 Unterstützt die folgenden Platzhalter: {pname} (Name der Testanwendung), {pid} (Prozess-ID), {asm} (Name der Eintragsassembly), {tfm} (Zielframeworkmoniker), {arch} (Prozessorarchitektur), {time} (Zeitstempel).
 Beispiel: „MyReport_{tfm}.xml“.</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.es.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">Nombre del informe XML de JUnit generado. Puede incluir una ruta de acceso relativa o absoluta; las rutas de acceso relativas se resuelven respecto al directorio de resultados de pruebas y se crean los directorios que falten.
+        <target state="needs-review-translation">Nombre del informe XML de JUnit generado. Puede incluir una ruta de acceso relativa o absoluta; las rutas de acceso relativas se resuelven respecto al directorio de resultados de pruebas y se crean los directorios que falten.
 Admite los siguientes marcadores de posición: {pname} (nombre de la aplicación de prueba), {pid} (id. de proceso), {asm} (nombre del ensamblado de entrada), {tfm} (moniker de la plataforma de destino), {arch} (arquitectura del proceso), {time} (marca de tiempo).
 Ejemplo: "MyReport_{tfm}.xml".</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">Le nom du rapport XML JUnit généré. Peut inclure un chemin d’accès relatif ou absolu. Les chemins relatifs sont résolus sur le répertoire des résultats des tests et les répertoires manquants sont créés.
+        <target state="needs-review-translation">Le nom du rapport XML JUnit généré. Peut inclure un chemin d’accès relatif ou absolu. Les chemins relatifs sont résolus sur le répertoire des résultats des tests et les répertoires manquants sont créés.
 Permet de prendre en charge les espaces réservés suivants: {pname} (nom de l’application de test), {pid} (ID de processus), {asm} (nom de l’assembly d’entrée), {tfm} (moniker de framework cible), {arch} (architecture du processus), {time} (horodateur).
 Exemple : 'MyReport_{tfm}.xml'.</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.it.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">Nome del report XML JUnit generato. Può includere un percorso relativo o assoluto. I percorsi relativi vengono risolti rispetto alla directory dei risultati dei test e vengono create le directory mancanti.
+        <target state="needs-review-translation">Nome del report XML JUnit generato. Può includere un percorso relativo o assoluto. I percorsi relativi vengono risolti rispetto alla directory dei risultati dei test e vengono create le directory mancanti.
 Supporta i seguenti segnaposto: {pname} (nome dell'applicazione di test), {pid} (ID processo), {asm} (nome dell'assembly di immissione), {tfm} (moniker framework di destinazione), {arch} (architettura processo), {time} (timestamp).
 Esempio: 'MyReport_{tfm}.xml'.</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">生成された JUnit XML レポートの名前。相対または絶対パスを含めることができます。相対パスはテスト結果ディレクトリを基準に解決され、存在しないディレクトリは作成されます。
+        <target state="needs-review-translation">生成された JUnit XML レポートの名前。相対または絶対パスを含めることができます。相対パスはテスト結果ディレクトリを基準に解決され、存在しないディレクトリは作成されます。
 次のプレースホルダーがサポートされています: {pname} (テスト アプリケーション名)、{pid} (プロセス ID)、{asm} (エントリ アセンブリ名)、{tfm} (ターゲット フレームワーク モニカー)、{arch} (プロセス アーキテクチャ)、{time} (タイムスタンプ)。
 例: 'MyReport_{tfm}.xml'。</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">생성된 JUnit XML 보고서의 이름입니다. 상대 경로 또는 절대 경로를 사용할 수 있습니다. 상대 경로는 테스트 결과 디렉터리를 기준으로 확인되며, 없는 디렉터리는 만들어집니다.
+        <target state="needs-review-translation">생성된 JUnit XML 보고서의 이름입니다. 상대 경로 또는 절대 경로를 사용할 수 있습니다. 상대 경로는 테스트 결과 디렉터리를 기준으로 확인되며, 없는 디렉터리는 만들어집니다.
 자리 표시자 {pname}(테스트 애플리케이션 이름), {pid}(프로세스 ID), {asm}(항목 어셈블리 이름), {tfm}(대상 프레임워크 모니커), {arch}(프로세스 아키텍처), {time}(타임스탬프)을(를) 지원합니다.
 예: 'MyReport_{tfm}.xml'.</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">Nazwa wygenerowanego raportu XML JUnit. Może zawierać ścieżkę względną lub bezwzględną; ścieżki względne są rozpoznawane względem katalogu wyników testów, a brakujące katalogi są tworzone.
+        <target state="needs-review-translation">Nazwa wygenerowanego raportu XML JUnit. Może zawierać ścieżkę względną lub bezwzględną; ścieżki względne są rozpoznawane względem katalogu wyników testów, a brakujące katalogi są tworzone.
 Obsługuje następujące symbole zastępcze: {pname} (nazwa aplikacji testowej), {pid} (identyfikator procesu), {asm} (nazwa zestawu wejściowego), {tfm} (moniker platformy docelowej), {arch} ()architektura procesu, {time} (sygnatura czasowa).
 Przykład: „MyReport_{tfm}.xml”.</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">O nome do relatório XML JUnit gerado. Pode incluir um caminho relativo ou absoluto; os caminhos relativos são resolvidos em relação ao diretório de resultados de teste, e os diretórios ausentes são criados.
+        <target state="needs-review-translation">O nome do relatório XML JUnit gerado. Pode incluir um caminho relativo ou absoluto; os caminhos relativos são resolvidos em relação ao diretório de resultados de teste, e os diretórios ausentes são criados.
 Dá suporte aos seguintes espaços reservados: {pname} (nome do aplicativo de teste), {pid} (ID do processo), {asm} (nome do assembly de entrada), {tfm} (moniker da estrutura de destino), {arch} (arquitetura do processo), {time} (carimbo de data/hora).
 Exemplo: 'MyReport_{tfm}.xml'.</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">Имя сгенерированного XML-отчета JUnit. Может включать относительный или абсолютный путь; относительные пути разрешаются относительно каталога результатов тестов, а отсутствующие каталоги создаются.
+        <target state="needs-review-translation">Имя сгенерированного XML-отчета JUnit. Может включать относительный или абсолютный путь; относительные пути разрешаются относительно каталога результатов тестов, а отсутствующие каталоги создаются.
 Поддерживает следующие заполнители: {pname} (имя тестового приложения), {pid} (идентификатор процесса), {asm} (имя входной сборки), {tfm} (моникер целевой платформы), {arch} (архитектура процесса), {time} (метка времени).
 Пример: "MyReport_{tfm}.xml".</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">Oluşturulan JUnit XML raporunun adı. Göreli veya mutlak yol içerebilir; göreli yollar test sonuçları dizinine göre çözümlenir ve eksik dizinler oluşturulur.
+        <target state="needs-review-translation">Oluşturulan JUnit XML raporunun adı. Göreli veya mutlak yol içerebilir; göreli yollar test sonuçları dizinine göre çözümlenir ve eksik dizinler oluşturulur.
 Şu yer tutucuları destekler: {pname} (test uygulaması adı), {pid} (işlem kimliği), {asm} (girdi derleme adı), {tfm} (hedef çerçeve bilinen adı), {arch} (işlem mimarisi), {time} (zaman damgası).
 Örnek: 'MyReport_{tfm}.xml'.</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">生成的 JUnit XML 报表的名称。可以包含相对路径或绝对路径；相对路径针对测试结果目录进行解析，并创建缺少的目录。
+        <target state="needs-review-translation">生成的 JUnit XML 报表的名称。可以包含相对路径或绝对路径；相对路径针对测试结果目录进行解析，并创建缺少的目录。
 支持以下占位符: {pname} (测试应用程序名称)、{pid} (进程 ID)、{asm} (入口程序集名称)、{tfm} (目标框架名字对象)、{arch} (进程体系结果)、{time} (时间戳)。
 示例: "MyReport_{tfm}.xml"。</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -61,10 +61,10 @@
         <source>The name of the generated JUnit XML report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.xml'.</source>
-        <target state="translated">產生的 JUnit XML 報告名稱。可以包含相對或絕對路徑; 系統會針對測試結果目錄解析相對路徑，並建立遺漏的目錄。
+        <target state="needs-review-translation">產生的 JUnit XML 報告名稱。可以包含相對或絕對路徑; 系統會針對測試結果目錄解析相對路徑，並建立遺漏的目錄。
 支援下列預留位置: {pname}(測試應用程式名稱)、{pid}(處理序識別碼)、{asm}(進入組件名稱)、{tfm}(目標 Framework Moniker)、{arch} (處理序結構)、{time}(時間戳記)。
 範例: 'MyReport_{tfm}.xml'。</target>
-        <note>Do not localize option name {Locked="--report-junit-filename"}, format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="'MyReport_{tfm}.xml'"}.</note>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".xml"}, or example file name {Locked="MyReport_{tfm}.xml"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-junit-filename' relative paths must stay under the test results directory (e.g. --report-junit-filename nested/myreport.xml)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/ExtensionResources.resx
@@ -212,7 +212,7 @@
     <value>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</value>
-    <comment>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</comment>
+    <comment>Do not localize format name {Locked=&quot;TRX&quot;}, placeholder tokens {Locked=&quot;{pname}&quot;}{Locked=&quot;{pid}&quot;}{Locked=&quot;{asm}&quot;}{Locked=&quot;{tfm}&quot;}{Locked=&quot;{arch}&quot;}{Locked=&quot;{time}&quot;}, file extension {Locked=&quot;.trx&quot;}, or example file name {Locked=&quot;MyReport_{tfm}.trx&quot;}.</comment>
   </data>
   <data name="TrxReportFileNameRequiresTrxReport" xml:space="preserve">
     <value>'--report-trx-filename' requires '--report-trx' to be enabled</value>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">Název vygenerované sestavy TRX. Může obsahovat relativní nebo absolutní cestu. Relativní cesty se překládají na adresář výsledků testů a vytvoří se chybějící adresáře.
+        <target state="needs-review-translation">Název vygenerované sestavy TRX. Může obsahovat relativní nebo absolutní cestu. Relativní cesty se překládají na adresář výsledků testů a vytvoří se chybějící adresáře.
 Podporuje následující zástupné symboly: {pname} (název testovací aplikace), {pid} (ID procesu), {asm} (název sestavení položky), {tfm} (moniker cílové architektury), {arch} (architektura procesu), {time} (časové razítko).
 Příklad: MyReport_{tfm}.trx.</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.de.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">Der Name des generierten TRX-Berichts. Kann einen relativen oder absoluten Pfad enthalten. Relative Pfade werden anhand des Verzeichnisses mit den Testergebnissen aufgelöst, und fehlende Verzeichnisse werden erstellt.
+        <target state="needs-review-translation">Der Name des generierten TRX-Berichts. Kann einen relativen oder absoluten Pfad enthalten. Relative Pfade werden anhand des Verzeichnisses mit den Testergebnissen aufgelöst, und fehlende Verzeichnisse werden erstellt.
 Unterstützt die folgenden Platzhalter: {pname} (Name der Testanwendung), {pid} (Prozess-ID), {asm} (Name der Eintragsassembly), {tfm} (Zielframeworkmoniker), {arch} (Prozessorarchitektur), {time} (Zeitstempel).
 Beispiel: „MyReport_{tfm}.trx“.</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.es.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">Nombre del informe TRX generado. Puede incluir una ruta de acceso relativa o absoluta; las rutas de acceso relativas se resuelven respecto al directorio de resultados de pruebas y se crean los directorios que falten.
+        <target state="needs-review-translation">Nombre del informe TRX generado. Puede incluir una ruta de acceso relativa o absoluta; las rutas de acceso relativas se resuelven respecto al directorio de resultados de pruebas y se crean los directorios que falten.
 Admite los siguientes marcadores de posición: {pname} (nombre de la aplicación de prueba), {pid} (id. de proceso), {asm} (nombre del ensamblado de entrada), {tfm} (moniker de la plataforma de destino), {arch} (arquitectura del proceso), {time} (marca de tiempo).
 Ejemplo: "MyReport_{tfm}.trx".</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">Le nom du rapport TRX généré. Peut inclure un chemin d’accès relatif ou absolu. Les chemins relatifs sont résolus sur le répertoire des résultats des tests et les répertoires manquants sont créés.
+        <target state="needs-review-translation">Le nom du rapport TRX généré. Peut inclure un chemin d’accès relatif ou absolu. Les chemins relatifs sont résolus sur le répertoire des résultats des tests et les répertoires manquants sont créés.
 Permet de prendre en charge les espaces réservés suivants: {pname} (nom de l’application de test), {pid} (ID de processus), {asm} (nom de l’assembly d’entrée), {tfm} (moniker de framework cible), {arch} (architecture du processus), {time} (horodateur).
 Exemple : 'MyReport_{tfm}.trx'.</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.it.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">Nome del report TRX generato. Può includere un percorso relativo o assoluto. I percorsi relativi vengono risolti rispetto alla directory dei risultati del test e le directory mancanti vengono create.
+        <target state="needs-review-translation">Nome del report TRX generato. Può includere un percorso relativo o assoluto. I percorsi relativi vengono risolti rispetto alla directory dei risultati del test e le directory mancanti vengono create.
 Supporta i seguenti segnaposto: {pname} (nome dell'applicazione di test), {pid} (ID processo), {asm} (nome dell'assembly di immissione), {tfm} (moniker framework di destinazione), {arch} (architettura processo), {time} (timestamp).
 Esempio: 'MyReport_{tfm}.trx'.</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">生成された TRX レポートの名前。相対パスまたは絶対パスを含めることができます。相対パスはテスト結果ディレクトリに対して解決され、存在しないディレクトリは作成されます。
+        <target state="needs-review-translation">生成された TRX レポートの名前。相対パスまたは絶対パスを含めることができます。相対パスはテスト結果ディレクトリに対して解決され、存在しないディレクトリは作成されます。
 次のプレースホルダーがサポートされています: {pname} (テスト アプリケーション名)、{pid} (プロセス ID)、{asm} (エントリ アセンブリ名)、{tfm} (ターゲット フレームワーク モニカー)、{arch} (プロセス アーキテクチャ)、{time} (タイムスタンプ)。
 例: 'MyReport_{tfm}.trx'。</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">생성된 TRX 보고서의 이름입니다. 상대 경로 또는 절대 경로를 사용할 수 있습니다. 상대 경로는 테스트 결과 디렉터리를 기준으로 확인되며, 없는 디렉터리는 만들어집니다.
+        <target state="needs-review-translation">생성된 TRX 보고서의 이름입니다. 상대 경로 또는 절대 경로를 사용할 수 있습니다. 상대 경로는 테스트 결과 디렉터리를 기준으로 확인되며, 없는 디렉터리는 만들어집니다.
 자리 표시자 {pname}(테스트 애플리케이션 이름), {pid}(프로세스 ID), {asm}(항목 어셈블리 이름), {tfm}(대상 프레임워크 모니커), {arch}(프로세스 아키텍처), {time}(타임스탬프)을(를) 지원합니다.
 예: 'MyReport_{tfm}.trx'.</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">Nazwa wygenerowanego raportu TRX. Może zawierać ścieżkę względną lub bezwzględną; ścieżki względne są rozpoznawane względem katalogu wyników testów, a brakujące katalogi są tworzone.
+        <target state="needs-review-translation">Nazwa wygenerowanego raportu TRX. Może zawierać ścieżkę względną lub bezwzględną; ścieżki względne są rozpoznawane względem katalogu wyników testów, a brakujące katalogi są tworzone.
 Obsługuje następujące symbole zastępcze: {pname} (nazwa aplikacji testowej), {pid} (identyfikator procesu), {asm} (nazwa zestawu wejściowego), {tfm} (moniker platformy docelowej), {arch} ()architektura procesu, {time} (sygnatura czasowa).
 Przykład: „MyReport_{tfm}.trx”.</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">O nome do relatório TRX gerado. Pode incluir um caminho relativo ou absoluto; os caminhos relativos são resolvidos em relação ao diretório de resultados de teste, e os diretórios ausentes são criados.
+        <target state="needs-review-translation">O nome do relatório TRX gerado. Pode incluir um caminho relativo ou absoluto; os caminhos relativos são resolvidos em relação ao diretório de resultados de teste, e os diretórios ausentes são criados.
 Dá suporte aos seguintes espaços reservados: {pname} (nome do aplicativo de teste), {pid} (ID do processo), {asm} (nome do assembly de entrada), {tfm} (moniker da estrutura de destino), {arch} (arquitetura do processo), {time} (carimbo de data/hora).
 Exemplo: 'MyReport_{tfm}.trx'.</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">Имя созданного отчета TRX. Может включать относительный или абсолютный путь; относительные пути разрешаются относительно каталога результатов тестов, а отсутствующие каталоги создаются.
+        <target state="needs-review-translation">Имя созданного отчета TRX. Может включать относительный или абсолютный путь; относительные пути разрешаются относительно каталога результатов тестов, а отсутствующие каталоги создаются.
 Поддерживает следующие заполнители: {pname} (имя тестового приложения), {pid} (идентификатор процесса), {asm} (имя входной сборки), {tfm} (моникер целевой платформы), {arch} (архитектура процесса), {time} (метка времени).
 Пример: "MyReport_{tfm}.trx".</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">Oluşturulan TRX raporunun adı. Göreli veya mutlak yol içerebilir; göreli yollar test sonuçları dizinine göre çözümlenir ve eksik dizinler oluşturulur.
+        <target state="needs-review-translation">Oluşturulan TRX raporunun adı. Göreli veya mutlak yol içerebilir; göreli yollar test sonuçları dizinine göre çözümlenir ve eksik dizinler oluşturulur.
 Şu yer tutucuları destekler: {pname} (test uygulaması adı), {pid} (işlem kimliği), {asm} (girdi derleme adı), {tfm} (hedef çerçeve bilinen adı), {arch} (işlem mimarisi), {time} (zaman damgası).
 Örnek: 'MyReport_{tfm}.trx'.</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">生成的 TRX 报表名称。可以包含相对路径或绝对路径；相对路径针对测试结果目录进行解析，并创建缺少的目录。
+        <target state="needs-review-translation">生成的 TRX 报表名称。可以包含相对路径或绝对路径；相对路径针对测试结果目录进行解析，并创建缺少的目录。
 支持以下占位符: {pname} (测试应用程序名称)、{pid} (进程 ID)、{asm} (入口程序集名称)、{tfm} (目标框架名字对象)、{arch} (进程体系结果)、{time} (时间戳)。
 示例: "MyReport_{tfm}.trx"。</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -126,10 +126,10 @@
         <source>The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
 Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
 Example: 'MyReport_{tfm}.trx'.</source>
-        <target state="translated">產生的 TRX 報告名稱。可以包含相對或絕對路徑; 系統會針對測試結果目錄解析相對路徑，並建立遺漏的目錄。
+        <target state="needs-review-translation">產生的 TRX 報告名稱。可以包含相對或絕對路徑; 系統會針對測試結果目錄解析相對路徑，並建立遺漏的目錄。
 支援下列預留位置: {pname}(測試應用程式名稱)、{pid}(處理序識別碼)、{asm}(進入組件名稱)、{tfm}(目標 Framework Moniker)、{arch} (處理序結構)、{time}(時間戳記)。
 範例: 'MyReport_{tfm}.trx'。</target>
-        <note>Do not localize option name {Locked="--report-trx-filename"}, format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="'MyReport_{tfm}.trx'"}.</note>
+        <note>Do not localize format name {Locked="TRX"}, placeholder tokens {Locked="{pname}"}{Locked="{pid}"}{Locked="{asm}"}{Locked="{tfm}"}{Locked="{arch}"}{Locked="{time}"}, file extension {Locked=".trx"}, or example file name {Locked="MyReport_{tfm}.trx"}.</note>
       </trans-unit>
       <trans-unit id="TrxReportFileNameRelativePathMustStayUnderResultsDirectory">
         <source>'--report-trx-filename' relative paths must stay under the test results directory (e.g. --report-trx-filename nested/myreport.trx)</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
@@ -216,7 +216,7 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</value>
-    <comment>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</comment>
+    <comment>{Locked=&quot;auto&quot;}{Locked=&quot;&apos;on&apos;&quot;}{Locked=&quot;true&quot;}{Locked=&quot;enable&quot;}{Locked=&quot;1&quot;}{Locked=&quot;off&quot;}{Locked=&quot;false&quot;}{Locked=&quot;disable&quot;}{Locked=&quot;0&quot;}{Locked=&quot;--progress off&quot;}{Locked=&quot;--ansi&quot;}{Locked=&quot;--no-ansi&quot;}</comment>
   </data>
   <data name="TerminalAnsiOptionInvalidArgument" xml:space="preserve">
     <value>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</value>
@@ -258,11 +258,11 @@ This option takes precedence over the deprecated --no-progress flag.</value>
   <data name="TerminalOutputOptionDescription" xml:space="preserve">
     <value>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</value>
-    <comment>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</comment>
+    <comment>{Locked=&quot;Minimal&quot;}{Locked=&quot;Normal&quot;}{Locked=&quot;Detailed&quot;}{Locked=&quot;--show-test-results&quot;}</comment>
   </data>
   <data name="TerminalOutputOptionInvalidArgument" xml:space="preserve">
     <value>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</value>
-    <comment>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</comment>
+    <comment>{Locked=&quot;--output&quot;}{Locked=&quot;Minimal&quot;}{Locked=&quot;Normal&quot;}{Locked=&quot;Detailed&quot;}</comment>
   </data>
   <data name="TerminalShowStdoutOptionDescription" xml:space="preserve">
     <value>Determines when to show captured standard output of a test.
@@ -299,19 +299,19 @@ Passing the option without a value turns it on.</value>
     <value>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</value>
-    <comment>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</comment>
+    <comment>Do not localize the values {Locked=&quot;&apos;passed&apos;&quot;}{Locked=&quot;failed&quot;}{Locked=&quot;skipped&quot;}{Locked=&quot;all&quot;}{Locked=&quot;none&quot;}{Locked=&quot;--output&quot;}{Locked=&quot;Minimal&quot;}{Locked=&quot;Normal&quot;}{Locked=&quot;Detailed&quot;}{Locked=&quot;--show-test-results&quot;}.</comment>
   </data>
   <data name="TerminalShowTestResultsOptionUnknownValueInvalidArgument" xml:space="preserve">
     <value>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</value>
-    <comment>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</comment>
+    <comment>{Locked=&quot;--show-test-results&quot;}{Locked=&quot;passed&quot;}{Locked=&quot;failed&quot;}{Locked=&quot;skipped&quot;}{Locked=&quot;all&quot;}{Locked=&quot;none&quot;}</comment>
   </data>
   <data name="TerminalShowTestResultsOptionEmptySelectionInvalidArgument" xml:space="preserve">
     <value>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</value>
-    <comment>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</comment>
+    <comment>{Locked=&quot;--show-test-results&quot;}{Locked=&quot;passed&quot;}{Locked=&quot;failed&quot;}{Locked=&quot;skipped&quot;}{Locked=&quot;all&quot;}{Locked=&quot;none&quot;}</comment>
   </data>
   <data name="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument" xml:space="preserve">
     <value>--show-test-results value 'all' or 'none' cannot be combined with any other value.</value>
-    <comment>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</comment>
+    <comment>{Locked=&quot;--show-test-results&quot;}{Locked=&quot;all&quot;}{Locked=&quot;none&quot;}</comment>
   </data>
   <data name="StandardError" xml:space="preserve">
     <value>Error output</value>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
@@ -441,7 +441,7 @@ When both --ansi and --no-ansi are provided, --ansi wins.</source>
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ When both --ansi and --no-ansi are provided, --ansi wins.</target>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Přednastavte bloky výsledků jednotlivých testů zobrazené v terminálu.
+        <target state="needs-review-translation">Přednastavte bloky výsledků jednotlivých testů zobrazené v terminálu.
 Platné hodnoty jsou Minimal, Normal a Detailed. Výchozí hodnota je Normal. K přesnému výběru výsledků použijte --show-test-results.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output očekává jeden parametr s hodnotou Minimal, Normal nebo Detailed.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output očekává jeden parametr s hodnotou Minimal, Normal nebo Detailed.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,8 +546,8 @@ Platné hodnoty jsou All, Failed, None. Výchozí hodnota je All (nebo Failed, k
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">Hodnotu all nebo none možnosti --show-test-results nelze kombinovat s žádnou jinou hodnotou.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">Hodnotu all nebo none možnosti --show-test-results nelze kombinovat s žádnou jinou hodnotou.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
@@ -556,17 +556,17 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
         <target state="new">Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results vyžaduje minimálně jednu z hodnot passed, failed, skipped, all nebo none.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results vyžaduje minimálně jednu z hodnot passed, failed, skipped, all nebo none.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results očekává jednu nebo více hodnot oddělených čárkami nebo mezerami z následujících možností: passed, failed, skipped, all nebo none.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results očekává jednu nebo více hodnot oddělených čárkami nebo mezerami z následujících možností: passed, failed, skipped, all nebo none.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
@@ -441,7 +441,7 @@ When both --ansi and --no-ansi are provided, --ansi wins.</source>
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ When both --ansi and --no-ansi are provided, --ansi wins.</target>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Legen Sie die pro Test angezeigten Ergebnisblöcke im Terminal fest.
+        <target state="needs-review-translation">Legen Sie die pro Test angezeigten Ergebnisblöcke im Terminal fest.
 Gültige Werte sind 'Minimal', 'Normal' und 'Detailed'. Der Standardwert ist 'Normal'. Verwenden Sie '--show-test-results' für eine genaue Auswahl des Ergebnisses.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">„--output“ erwartet einen einzelnen Parameter mit dem Wert 'Minimal', 'Normal' oder 'Detailed'.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">„--output“ erwartet einen einzelnen Parameter mit dem Wert 'Minimal', 'Normal' oder 'Detailed'.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Gültige Werte sind „All“, „Failed“ und „None“. Der Standardwert ist
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">Die Werte 'all' oder 'none' für '--show-test-results' können nicht mit anderen Werten kombiniert werden.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">Die Werte 'all' oder 'none' für '--show-test-results' können nicht mit anderen Werten kombiniert werden.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">Wählen Sie aus, welche Testergebnisse im Terminal einen Ergebnisblock pro Test mit zugehörigen Details, Stacktrace und erfasster Ausgabe ausgeben.
+        <target state="needs-review-translation">Wählen Sie aus, welche Testergebnisse im Terminal einen Ergebnisblock pro Test mit zugehörigen Details, Stacktrace und erfasster Ausgabe ausgeben.
 Gültige Werte sind 'passed', 'failed' (deckt auch fehlerhafte, abgelaufene und abgebrochene Tests ab), 'skipped', 'all' und 'none'. Mehrere Werte können als durch Kommas oder Leerzeichen getrennte Liste oder durch mehrmaliges Angeben der Option kombiniert werden. Die Werte 'all' und 'none' können nicht mit anderen Werten kombiniert werden.
 Der Standardwert ist 'failed', wenn '--output' auf 'Minimal' festgelegt ist, 'failed' und 'skipped', wenn er 'Normal' ist oder weggelassen wird, und 'all', wenn er 'Detailed' ist. Ein explizites '--show-test-results' hat immer Vorrang vor '--output', unabhängig von der Reihenfolge der übergebenen Optionen.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">„--show-test-results“ erfordert mindestens einen der folgenden Werte: 'passed', 'failed', 'skipped', 'all' oder 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">„--show-test-results“ erfordert mindestens einen der folgenden Werte: 'passed', 'failed', 'skipped', 'all' oder 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">„--show-test-results“ erwartet einen oder mehrere durch Kommas oder Leerzeichen getrennte Werte. Mögliche Werte sind 'passed', 'failed', 'skipped', 'all' und 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">„--show-test-results“ erwartet einen oder mehrere durch Kommas oder Leerzeichen getrennte Werte. Mögliche Werte sind 'passed', 'failed', 'skipped', 'all' und 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">Controlar si se emiten caracteres de escape ANSI.
+        <target state="needs-review-translation">Controlar si se emiten caracteres de escape ANSI.
 Los valores válidos son 'auto' (valor predeterminado), 'on' (también acepta 'true', 'enable', '1') o 'off' (también acepta 'false', 'disable', '0').
 'on' fuerza los códigos de escape ANSI (incluido el movimiento del cursor) incluso cuando se redirige stdout; empareje con --progress off si solo quiere colores.
 Cuando se proporcionan --ansi y --no-ansi, --ansi gana.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ Cuando se proporcionan --ansi y --no-ansi, --ansi gana.</target>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Preestablecer los bloques de resultados por prueba que se muestran en el terminal.
+        <target state="needs-review-translation">Preestablecer los bloques de resultados por prueba que se muestran en el terminal.
 Los valores válidos son 'Minimal', 'Normal', 'Detailed'. El valor predeterminado es 'Normal'. Use '--show-test-results' para la selección precisa de resultados.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output espera un único parámetro con el valor 'Minimal', 'Normal' o 'Detailed'.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output espera un único parámetro con el valor 'Minimal', 'Normal' o 'Detailed'.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Los valores válidos son "All", "Failed", "None". El valor predeterminado es "Al
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">--show-test-results el valor 'all' o 'none' no se puede combinar con ningún otro valor.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results el valor 'all' o 'none' no se puede combinar con ningún otro valor.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">Selecciona qué resultados de prueba representan un bloque de resultados por prueba (con sus detalles informativos, seguimiento de la pila y salida capturada) en el terminal.
+        <target state="needs-review-translation">Selecciona qué resultados de prueba representan un bloque de resultados por prueba (con sus detalles informativos, seguimiento de la pila y salida capturada) en el terminal.
 Los valores válidos son 'passed', 'failed' (también cubre las pruebas con errores, con tiempo de espera agotado y cancelado), 'skipped', 'all' y 'none'. Combine varios valores como una lista separada por comas o espacios, o repita la opción; 'all' y 'none' no se pueden combinar con ningún otro valor.
 El valor predeterminado es 'failed' cuando '--output' es 'Minimal', 'failed' y 'skipped' cuando es 'Normal' u omitido, y 'all' cuando es 'Detailed'. Un '--show-test-results' explícito siempre tiene prioridad sobre '--output', independientemente del orden en que se pasen.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results requiere al menos un valor de 'passed', 'failed', 'skipped', 'all' o 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results requiere al menos un valor de 'passed', 'failed', 'skipped', 'all' o 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results espera uno o más valores separados por comas o espacios de 'passed', 'failed', 'skipped', 'all' o 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results espera uno o más valores separados por comas o espacios de 'passed', 'failed', 'skipped', 'all' o 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">Déterminez si des caractères d’échappement ANSI sont émis.
+        <target state="needs-review-translation">Déterminez si des caractères d’échappement ANSI sont émis.
 Les valeurs valides sont 'auto' (par défaut), 'on' (accepte également 'true', 'enable', '1') ou 'off' (accepte également 'false', 'disable', '0').
 'on' force les codes d’échappement ANSI (notamment le déplacement du curseur) même lorsque stdout est redirigé, associez-le à --progress off si vous ne voulez que des couleurs.
 Lorsque --ansi et --no-ansi sont fournis, --ansi est prioritaire.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ Lorsque --ansi et --no-ansi sont fournis, --ansi est prioritaire.</target>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Prédéfinissez les blocs de résultats par test affichés dans le terminal.
+        <target state="needs-review-translation">Prédéfinissez les blocs de résultats par test affichés dans le terminal.
 Les valeurs valides sont 'Minimal', 'Normal', 'Detailed'. La valeur par défaut est 'Normal'. Utilisez '--show-test-results' pour sélectionner précisément les résultats.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output attend un seul paramètre avec la valeur 'Minimal', 'Normal' ou 'Detailed'.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output attend un seul paramètre avec la valeur 'Minimal', 'Normal' ou 'Detailed'.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Les valeurs valides sont « All », « Failed » et « None ». La valeur 
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">Vous ne pouvez pas combiner la valeur 'all' ou 'none' de --show-test-results avec une autre valeur.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">Vous ne pouvez pas combiner la valeur 'all' ou 'none' de --show-test-results avec une autre valeur.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">Sélectionne les résultats de test à afficher sous forme de bloc de résultats par test, avec leurs détails, leur trace de pile et leur sortie capturée, dans le terminal.
+        <target state="needs-review-translation">Sélectionne les résultats de test à afficher sous forme de bloc de résultats par test, avec leurs détails, leur trace de pile et leur sortie capturée, dans le terminal.
 Les valeurs valides sont 'passed', 'failed' (couvre aussi les tests en erreur, expirés et annulés), 'skipped', 'all' et 'none'. Combinez plusieurs valeurs dans une liste séparée par des virgules ou des espaces, ou en répétant l’option, vous ne pouvez pas combiner 'all' et 'none' avec aucune autre valeur.
 La valeur par défaut est 'failed' lorsque '--output' est équivalent à 'Minimal', 'failed' et 'skipped' lorsqu’il est équivalent à 'Normal' ou s’il est omis, et 'all' lorsqu’il est équivalent à 'Detailed'. Un élément '--show-test-results' explicite prévaut toujours sur '--output', quel que soit l’ordre dans lequel ces options sont transmises.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results nécessite au moins une valeur parmi 'passed', 'failed', 'skipped', 'all' ou 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results nécessite au moins une valeur parmi 'passed', 'failed', 'skipped', 'all' ou 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results attend une ou plusieurs valeurs séparées par des virgules ou des espaces parmi 'passed', 'failed', 'skipped', 'all' ou 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results attend une ou plusieurs valeurs séparées par des virgules ou des espaces parmi 'passed', 'failed', 'skipped', 'all' ou 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">Controllare se vengono generati caratteri di escape ANSI.
+        <target state="needs-review-translation">Controllare se vengono generati caratteri di escape ANSI.
 I valori validi sono ''auto'' (impostazione predefinita), ''on'' (accetta anche ''true'', ''enable'', ''1'') o ''off'' (accetta anche ''false'', ''disable'', '0').
 ''on'' forza i codici di escape ANSI (incluso lo spostamento del cursore) anche quando stdout viene reindirizzato; associarlo a --progress off se si desiderano solo colori.
 Quando vengono specificati sia --ansi sia --no-ansi, --ansi ha la priorità.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ Quando vengono specificati sia --ansi sia --no-ansi, --ansi ha la priorità.</ta
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Preimposta i blocchi dei risultati per test mostrati nel terminale.
+        <target state="needs-review-translation">Preimposta i blocchi dei risultati per test mostrati nel terminale.
 I valori validi sono 'Minimal', 'Normal' e 'Detailed'. L'impostazione predefinita è 'Normal'. Usa '--show-test-results' per selezionare con precisione i risultati.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output prevede un singolo parametro con un valore 'Minimal', 'Normal' o 'Detailed'.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output prevede un singolo parametro con un valore 'Minimal', 'Normal' o 'Detailed'.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ I valori validi sono 'All', 'Failed', 'None'. L'impostazione predefinita è 'All
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">Non è possibile combinare il valore '--show-test-results' 'all' o 'none' con altri valori.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">Non è possibile combinare il valore '--show-test-results' 'all' o 'none' con altri valori.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">Consente di selezionare quali risultati di test visualizzare in un blocco di risultati per test (con i dettagli informativi, l'analisi dello stack e l'output acquisito) nel terminale.
+        <target state="needs-review-translation">Consente di selezionare quali risultati di test visualizzare in un blocco di risultati per test (con i dettagli informativi, l'analisi dello stack e l'output acquisito) nel terminale.
 I valori validi sono 'passed', 'failed' (comprende anche i test con errori, in timeout e annullati), 'skipped', 'all' e 'none'. Combina più valori come elenco separato da virgole o spazi, oppure ripetendo l'opzione; non è possibile combinare 'all' e 'none' con altri valori.
 Il valore predefinito è 'failed' quando '--output' è 'Minimal', 'failed' e 'skipped' quando è 'Normal', oppure non è specificato, e 'all' quando è 'Detailed'. Un '--show-test-results' esplicito ha sempre la precedenza su '--output', indipendentemente dall'ordine in cui vengono passati.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results richiede almeno un valore tra 'passed', 'failed', 'skipped', 'all' o 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results richiede almeno un valore tra 'passed', 'failed', 'skipped', 'all' o 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results si aspetta uno o più valori, separati da virgole o spazi, tra 'passed', 'failed', 'skipped', 'all' o 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results si aspetta uno o più valori, separati da virgole o spazi, tra 'passed', 'failed', 'skipped', 'all' o 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">ANSI エスケープ文字を出力するかどうかを制御します。
+        <target state="needs-review-translation">ANSI エスケープ文字を出力するかどうかを制御します。
 有効な値は、'auto' (既定値)、'on' ('true'、'enable'、'1' も指定可能)、または 'off' ('false'、'disable'、'0' も指定可能) です。
 'on' を指定すると、stdout がリダイレクトされている場合でも、ANSI エスケープ コード (カーソルの移動を含む) が強制的に使用されます。色だけを使用する場合は、--progress off と組み合わせてください。
 --ansi と --no-ansi の両方が指定されている場合は、--ansi が優先されます。</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ When both --ansi and --no-ansi are provided, --ansi wins.</source>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">ターミナルに表示されるテストごとの結果ブロックを事前設定します。
+        <target state="needs-review-translation">ターミナルに表示されるテストごとの結果ブロックを事前設定します。
 有効な値は 'Minimal'、'Normal'、'Detailed' です。既定値は 'Normal' です。正確な結果を選択するには '--show-test-results' を使用します。</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output には、'Minimal'、'Normal'、または 'Detailed' のいずれか 1 つの値を持つ単一のパラメーターが必要です。</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output には、'Minimal'、'Normal'、または 'Detailed' のいずれか 1 つの値を持つ単一のパラメーターが必要です。</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">--show-test-results の値 'all' または 'none' は、他の値と組み合わせることはできません。</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results の値 'all' または 'none' は、他の値と組み合わせることはできません。</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">ターミナルにテストごとの結果ブロック (詳細情報、スタック トレース、キャプチャされた出力を含む) をレンダリングするテスト結果の種類を選択します。
+        <target state="needs-review-translation">ターミナルにテストごとの結果ブロック (詳細情報、スタック トレース、キャプチャされた出力を含む) をレンダリングするテスト結果の種類を選択します。
 有効な値は 'passed'、'failed' (エラー、タイムアウト、およびキャンセルされたテストも含む)、'skipped'、'all'、'none' です。複数の値は、コンマ区切りまたはスペース区切りのリストとして指定するか、オプションを繰り返して指定します。'all' と 'none' は、他の値と組み合わせることはできません。
 '--output' が 'Minimal' の場合の既定値は 'failed'、'Normal' の場合または省略時は 'failed' と 'skipped'、'Detailed' の場合は 'all' です。明示的な '--show-test-results' は、指定する順序にかかわらず、常に '--output' よりも優先されます。</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results には、'passed'、'failed'、'skipped'、'all'、'none' のいずれかの値を少なくとも 1 つ指定する必要があります。</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results には、'passed'、'failed'、'skipped'、'all'、'none' のいずれかの値を少なくとも 1 つ指定する必要があります。</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results には、'passed'、'failed'、'skipped'、'all'、'none' のいずれかの値を 1 つ以上、コンマ区切りまたはスペース区切りで指定する必要があります。</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results には、'passed'、'failed'、'skipped'、'all'、'none' のいずれかの値を 1 つ以上、コンマ区切りまたはスペース区切りで指定する必要があります。</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">ANSI 이스케이프 문자를 출력할지 여부를 제어합니다.
+        <target state="needs-review-translation">ANSI 이스케이프 문자를 출력할지 여부를 제어합니다.
 유효한 값은 'auto'(기본값), 'on' ('true', 'enable', '1'도 허용) 또는 'off'('false', 'disable', '0'도 허용)입니다.
 'on'은 stdout이 리디렉션되어도 ANSI 이스케이프 코드(커서 이동 포함)를 강제로 적용합니다. 색상만 적용하려면 --progress off와 함께 사용하세요.
 --ansi와 --no-ansi가 모두 지정되면 --ansi가 우선합니다.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ When both --ansi and --no-ansi are provided, --ansi wins.</source>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">터미널에 표시된 테스트별 결과 블록을 미리 설정합니다.
+        <target state="needs-review-translation">터미널에 표시된 테스트별 결과 블록을 미리 설정합니다.
 유효한 값은 'Minimal', 'Normal', 'Detailed'입니다. 기본값은 'Normal'입니다. 정확한 결과를 선택하기 위해 '--show-test-results'를 사용합니다.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output에는 값이 'Minimal', 'Normal' 또는 'Detailed'인 단일 매개 변수가 필요합니다.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output에는 값이 'Minimal', 'Normal' 또는 'Detailed'인 단일 매개 변수가 필요합니다.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">--show-test-results 값 'all' 또는 'none'은 다른 값과 결합할 수 없습니다.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results 값 'all' 또는 'none'은 다른 값과 결합할 수 없습니다.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">터미널에서 테스트별 결과 블록(정보 세부 정보, 스택 추적 및 캡처된 출력 포함)을 렌더링하는 테스트 결과를 선택합니다.
+        <target state="needs-review-translation">터미널에서 테스트별 결과 블록(정보 세부 정보, 스택 추적 및 캡처된 출력 포함)을 렌더링하는 테스트 결과를 선택합니다.
 유효한 값은 'passed', 'failed'(오류 발생, 시간 초과 및 취소된 테스트 포함), 'skipped', 'all' 및 'none'입니다. 여러 값을 쉼표 또는 공백으로 구분된 목록으로 결합하거나 옵션을 반복하여 결합합니다. 'all' 및 'none'은 다른 값과 결합할 수 없습니다.
 기본값은 '--output'이 'Minimal'일 때는 'failed'이고, 'Normal'이거나 생략된 경우에는 'failed'와 'skipped'이며, 'Detailed'일 때는 'all'입니다. 명시적 '--show-test-results'는 전달 순서에 관계없이 항상 '--output'보다 우선합니다.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results에는 'passed', 'failed', 'skipped', 'all' 또는 'none' 중 하나 이상의 값이 필요합니다.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results에는 'passed', 'failed', 'skipped', 'all' 또는 'none' 중 하나 이상의 값이 필요합니다.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results에는 'passed', 'failed', 'skipped', 'all' 또는 'none' 중 하나 이상의 쉼표 또는 공백으로 구분된 값이 필요합니다.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results에는 'passed', 'failed', 'skipped', 'all' 또는 'none' 중 하나 이상의 쉼표 또는 공백으로 구분된 값이 필요합니다.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
@@ -441,7 +441,7 @@ When both --ansi and --no-ansi are provided, --ansi wins.</source>
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ When both --ansi and --no-ansi are provided, --ansi wins.</target>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Wstępnie ustawiono bloki wyników dla poszczególnych testów wyświetlane w terminalu.
+        <target state="needs-review-translation">Wstępnie ustawiono bloki wyników dla poszczególnych testów wyświetlane w terminalu.
 Prawidłowe wartości to 'Minimal', 'Normal', or 'Detailed'. Wartość domyślna to 'Normal'. Aby precyzyjnie wybrać wyniki, użyj opcji '--show-test-results'.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output oczekuje jednego parametru o wartości 'Minimal', 'Normal', or 'Detailed'.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output oczekuje jednego parametru o wartości 'Minimal', 'Normal', or 'Detailed'.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Prawidłowe wartości to „All”, „Failed”, „None”. Wartość domyśln
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">Wartości --show-test-results: wartości 'all' lub 'none' nie można łączyć z żadną inną wartością.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">Wartości --show-test-results: wartości 'all' lub 'none' nie można łączyć z żadną inną wartością.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">Określa, które wyniki testów powodują wyświetlenie w terminalu bloku wyników dla danego testu (wraz z informacjami szczegółowymi, śladem stosu i przechwyconym wyjściem).
+        <target state="needs-review-translation">Określa, które wyniki testów powodują wyświetlenie w terminalu bloku wyników dla danego testu (wraz z informacjami szczegółowymi, śladem stosu i przechwyconym wyjściem).
 Dopuszczalne wartości to 'passed', 'failed' (obejmuje to również testy zakończone błędem, przekroczeniem limitu czasu i anulowane), 'skipped', 'all', and 'none'. Wiele wartości można połączyć, tworząc listę rozdzieloną przecinkami lub spacjami, albo poprzez powtórzenie opcji; wartości 'all' i 'none' nie można łączyć z żadną inną wartością.
 Domyślną wartością jest 'failed', gdy opcja '--output' ma wartość 'Minimal', 'failed' i 'skipped', gdy ma wartość 'Normal' lub została pominięta; oraz 'all', gdy ma wartość 'Detailed'. Jawny element '--show-test-results' zawsze ma pierwszeństwo przed opcją '--output', niezależnie od kolejności, w jakiej został przekazany.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">Parametr --show-test-results wymaga podania co najmniej jednej wartości spośród: 'passed', 'failed', 'skipped', 'all', lub 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">Parametr --show-test-results wymaga podania co najmniej jednej wartości spośród: 'passed', 'failed', 'skipped', 'all', lub 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">Parametr --show-test-results oczekuje jednej lub więcej wartości oddzielonych przecinkami lub spacjami, spośród następujących: 'passed', 'failed', 'skipped', 'all', lub 'none'.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">Parametr --show-test-results oczekuje jednej lub więcej wartości oddzielonych przecinkami lub spacjami, spośród następujących: 'passed', 'failed', 'skipped', 'all', lub 'none'.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">Controle se os caracteres de escape ANSI são emitidos.
+        <target state="needs-review-translation">Controle se os caracteres de escape ANSI são emitidos.
 Os valores válidos são 'auto' (padrão), 'on' (também aceita 'true', 'enable', '1') ou 'off' (também aceita 'false', 'disable', '0').
 'on' força códigos de escape ANSI (incluindo movimento de cursor) mesmo quando stdout é redirecionado; emparelhe-o com --progress off se você quiser apenas cores.
 Quando --ansi e --no-ansi são fornecidos, --ansi ganha.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ Quando --ansi e --no-ansi são fornecidos, --ansi ganha.</target>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Defina previamente os blocos de resultados por teste mostrados no terminal.
+        <target state="needs-review-translation">Defina previamente os blocos de resultados por teste mostrados no terminal.
 Os valores válidos são ''Minimal'', ''Normal'' e ''Detailed''. O padrão é ''Normal''. Use ''--show-test-results'' para selecionar o resultado com precisão.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output espera um único parâmetro com o valor 'Minimal', 'Normal', ou 'Detailed'.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output espera um único parâmetro com o valor 'Minimal', 'Normal', ou 'Detailed'.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Os valores válidos são 'All', 'Failed', 'None'. O padrão é 'All' (ou 'Failed
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">O valor de ''--show-test-results'' ''all'' ou ''none'' não pode ser combinado com nenhum outro valor.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">O valor de ''--show-test-results'' ''all'' ou ''none'' não pode ser combinado com nenhum outro valor.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">Seleciona quais resultados de teste são exibidos em um bloco de resultado por teste (com seus detalhes informativos, rastreamento de pilha e saída capturada) no terminal.
+        <target state="needs-review-translation">Seleciona quais resultados de teste são exibidos em um bloco de resultado por teste (com seus detalhes informativos, rastreamento de pilha e saída capturada) no terminal.
 Os valores válidos são ''passed'', ''failed'' (também inclui testes com erro, com tempo limite e cancelados), ''skipped'', ''all'' e ''none''. Combine vários valores em uma lista separada por vírgulas ou espaços ou repetindo a opção; ''all'' e ''none'' não podem ser combinados com nenhum outro valor.
 O padrão é ''failed'' quando ''--output'' é ''Minimal'', ''failed'' e ''skipped'' quando é ''Normal'' ou omitido, e ''all'' quando é ''Detailed''. Um ''--show-test-results'' explícito sempre tem precedência sobre ''--output'', independentemente da ordem em que forem informados.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results requer pelo menos um valor entre ''passed'', ''failed'', ''skipped'', ''all'' ou ''none''.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results requer pelo menos um valor entre ''passed'', ''failed'', ''skipped'', ''all'' ou ''none''.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results espera um ou mais valores separados por vírgula ou espaço entre ''passed'', ''failed'', ''skipped'', ''all'' ou ''none''.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results espera um ou mais valores separados por vírgula ou espaço entre ''passed'', ''failed'', ''skipped'', ''all'' ou ''none''.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
@@ -441,7 +441,7 @@ When both --ansi and --no-ansi are provided, --ansi wins.</source>
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ When both --ansi and --no-ansi are provided, --ansi wins.</target>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Предварительно задает блоки результатов каждого теста, отображаемые в терминале.
+        <target state="needs-review-translation">Предварительно задает блоки результатов каждого теста, отображаемые в терминале.
 Допустимые значения:"Minimal", "Normal" или "Detailed". Значение по умолчанию: "Normal". Используйте "--show-test-results" для точного выбора результатов.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output ожидает один параметр со значением "Minimal", "Normal" или "Detailed".</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output ожидает один параметр со значением "Minimal", "Normal" или "Detailed".</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,8 +546,8 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">Значение "--show-test-results" "all" или "none" нельзя использовать вместе с любым другим значением.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">Значение "--show-test-results" "all" или "none" нельзя использовать вместе с любым другим значением.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
@@ -556,17 +556,17 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
         <target state="new">Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results требует указать как минимум одно из следующих значений: "passed", "failed", "skipped", "all" или "none".</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results требует указать как минимум одно из следующих значений: "passed", "failed", "skipped", "all" или "none".</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results ожидает одно или несколько из следующих значений: "passed", "failed", "skipped", "all" или "none", разделенных запятыми или пробелами.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results ожидает одно или несколько из следующих значений: "passed", "failed", "skipped", "all" или "none", разделенных запятыми или пробелами.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">ANSI kaçış karakterlerinin yayılıp yayılmadığını denetleyin.
+        <target state="needs-review-translation">ANSI kaçış karakterlerinin yayılıp yayılmadığını denetleyin.
 Geçerli değerler: 'auto' (varsayılan), 'on' ('true', 'enable', '1' değerlerini de kabul eder) ve 'off' ('false', 'disable', '0' değerlerini de kabul eder).
 'on' değeri, stdout yeniden yönlendirildiğinde bile ANSI kaçış kodlarını (imleç hareketi dahil) zorlar. Yalnızca renk istiyorsanız --progress off ile birlikte kullanın.
 Hem --ansi hem de --no-ansi birlikte sağlandığında --ansi öncelikli olur.</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ Hem --ansi hem de --no-ansi birlikte sağlandığında --ansi öncelikli olur.</
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">Terminalde gösterilen test başına sonuç bloklarını önceden ayarlayın.
+        <target state="needs-review-translation">Terminalde gösterilen test başına sonuç bloklarını önceden ayarlayın.
 Geçerli değerler: 'Minimal', 'Normal', 'Detailed'. Varsayılan değer: 'Normal'. Kesin sonuç seçimi için '--show-test-results' kullanın.</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output 'Minimal', 'Normal' veya 'Detailed' değerine sahip tek bir parametre bekliyor.</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output 'Minimal', 'Normal' veya 'Detailed' değerine sahip tek bir parametre bekliyor.</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Geçerli değerler: 'All', 'Failed', 'None'. Varsayılan değer 'All' (veya bir 
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">--show-test-results değeri 'all' veya 'none', başka hiçbir değerle birlikte kullanılamaz.</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results değeri 'all' veya 'none', başka hiçbir değerle birlikte kullanılamaz.</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">Terminalde hangi test sonuçlarının test başına sonuç bloğunu (bilgilendirici ayrıntıları, yığın izlemesi ve yakalanan çıktısıyla birlikte) oluşturduğunu seçer.
+        <target state="needs-review-translation">Terminalde hangi test sonuçlarının test başına sonuç bloğunu (bilgilendirici ayrıntıları, yığın izlemesi ve yakalanan çıktısıyla birlikte) oluşturduğunu seçer.
 Geçerli değerler 'passed', 'failed' (hatalı, zaman aşımına uğramış ve iptal edilmiş testleri de kapsar) 'skipped', 'all' ve 'none' değerleridir. Birden çok değeri virgülle veya boşlukla ayrılmış bir liste olarak ya da seçeneği yineleyerek birleştirin; 'all' ve 'none' başka hiçbir değerle birleştirilemez.
 '--output' 'Minimal' olduğunda varsayılan değer 'failed', 'Normal' olduğunda veya belirtilmediğinde 'failed' ve 'skipped', 'Detailed' olduğunda ise 'all' değeridir. Açıkça belirtilen '--show-test-results', hangi sırayla geçirildiğine bakılmaksızın her zaman '--output' değerinden önceliklidir.</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results, 'passed', 'failed', 'skipped', 'all' veya 'none' değerlerinden en az birini gerektiriyor.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results, 'passed', 'failed', 'skipped', 'all' veya 'none' değerlerinden en az birini gerektiriyor.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results, virgülle veya boşlukla ayrılmış olarak 'passed', 'failed', 'skipped', 'all' veya 'none' değerlerinden birini veya birden fazlasını bekliyor.</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results, virgülle veya boşlukla ayrılmış olarak 'passed', 'failed', 'skipped', 'all' veya 'none' değerlerinden birini veya birden fazlasını bekliyor.</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">控制是否发出 ANSI 转义字符。
+        <target state="needs-review-translation">控制是否发出 ANSI 转义字符。
 有效值为 'auto' (默认值)、'on' (还接受 'true'、'enable'、'1')或 'off' (还接受 'false'、'disable'、'0')。
 'on' 会强制使用 ANSI 转义代码（包括光标移动），即使 stdout 被重定向也是如此；如果只需要颜色，请将其与 --progress off 一起使用。
 同时提供 --ansi 和 --no-ansi 时，--ansi 将生效。</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ When both --ansi and --no-ansi are provided, --ansi wins.</source>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">预设终端中显示的每测试结果块。
+        <target state="needs-review-translation">预设终端中显示的每测试结果块。
 有效值为 'Minimal'、'Normal'、'Detailed'。默认值为 'Normal'。使用 '--show-test-results' 进行精确的结果选择。</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output 需要值为 'Minimal'、'Normal'或 'Detailed' 的单个参数。</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output 需要值为 'Minimal'、'Normal'或 'Detailed' 的单个参数。</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">--show-test-results 值 'all' 或 'none' 不能与任何其他值组合。</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results 值 'all' 或 'none' 不能与任何其他值组合。</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">选择哪些测试结果在终端中呈现每测试结果块(包含其信息性详细信息、堆栈跟踪和捕获的输出)。
+        <target state="needs-review-translation">选择哪些测试结果在终端中呈现每测试结果块(包含其信息性详细信息、堆栈跟踪和捕获的输出)。
 有效值为 'passed'、'failed'(还包括错误、超时和已取消的测试)、'skipped'、'all' 和 'none'。将多个值组合为逗号或空格分隔列表，或重复该选项；'all' 和 'none' 不能与任何其他值组合。
 当 '--output' 为 'Minimal' 时，默认值为 'failed'，当它为 'Normal' 或省略时，默认值为 'failed' 和 'skipped'，当它为 'Detailed' 时，则为 'all'。显式 '--show-test-results' 始终优先于 '--output'，而无论它们的传入顺序如何。</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results 至少需要一个来自 'passed'、'failed'、'skipped'、'all' 或 'none' 的值。</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results 至少需要一个来自 'passed'、'failed'、'skipped'、'all' 或 'none' 的值。</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results 需要一个或多个 'passed'、'failed'、'skipped'、'all' 或 'none' 值并使用逗号或空格分隔。</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results 需要一个或多个 'passed'、'failed'、'skipped'、'all' 或 'none' 值并使用逗号或空格分隔。</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
@@ -437,11 +437,11 @@
 Valid values are 'auto' (default), 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0').
 'on' forces ANSI escape codes (including cursor movement) even when stdout is redirected; pair it with --progress off if you only want colors.
 When both --ansi and --no-ansi are provided, --ansi wins.</source>
-        <target state="translated">控制是否發出 ANSI 逸出字元。
+        <target state="needs-review-translation">控制是否發出 ANSI 逸出字元。
 有效值為 'auto' (預設值)、'on' (也接受 'true'、'enable'、'1') 或 'off' (也接受 'false'、'disable'、'0')。
 即使 stdout 已重新導向，'on' 會強制 ANSI 逸出程式碼 (包括游標移動); 如果您只想要色彩，將它與 --progress off 配對。
 同時提供 --ansi 和 --no-ansi 時,--ansi 優先。</target>
-        <note>{Locked="'auto'"}{Locked="'on'"}{Locked="'true'"}{Locked="'enable'"}{Locked="'1'"}{Locked="'off'"}{Locked="'false'"}{Locked="'disable'"}{Locked="'0'"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
+        <note>{Locked="auto"}{Locked="'on'"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="off"}{Locked="false"}{Locked="disable"}{Locked="0"}{Locked="--progress off"}{Locked="--ansi"}{Locked="--no-ansi"}</note>
       </trans-unit>
       <trans-unit id="TerminalAnsiOptionInvalidArgument">
         <source>--ansi expects a single parameter with value 'auto', 'on' (or 'true', 'enable', '1') or 'off' (or 'false', 'disable', '0').</source>
@@ -461,14 +461,14 @@ When both --ansi and --no-ansi are provided, --ansi wins.</source>
       <trans-unit id="TerminalOutputOptionDescription">
         <source>Preset the per-test result blocks shown in the terminal.
 Valid values are 'Minimal', 'Normal', 'Detailed'. Default is 'Normal'. Use '--show-test-results' for precise outcome selection.</source>
-        <target state="translated">預設終端機中顯示的每個測試結果區塊。
+        <target state="needs-review-translation">預設終端機中顯示的每個測試結果區塊。
 有效值為 'Minimal'、'Normal'、'Detailed'。預設為 'Normal'。使用 '--show-test-results' 以精確選取結果。</target>
-        <note>{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}</note>
+        <note>{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}</note>
       </trans-unit>
       <trans-unit id="TerminalOutputOptionInvalidArgument">
         <source>--output expects a single parameter with value 'Minimal', 'Normal', or 'Detailed'.</source>
-        <target state="translated">--output 需要值為 'Minimal'、'Normal' 或 'Detailed' 的單一參數。</target>
-        <note>{Locked="--output"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}</note>
+        <target state="needs-review-translation">--output 需要值為 'Minimal'、'Normal' 或 'Detailed' 的單一參數。</target>
+        <note>{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}</note>
       </trans-unit>
       <trans-unit id="TerminalProgressHeartbeat">
         <source>running... {0} completed, {1} failed</source>
@@ -546,27 +546,27 @@ Valid values are 'All', 'Failed', 'None'. Default is 'All' (or 'Failed' when an 
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionAllOrNoneCombinedInvalidArgument">
         <source>--show-test-results value 'all' or 'none' cannot be combined with any other value.</source>
-        <target state="translated">--show-test-results 的值 'all' 或 'none' 不能與任何其他值組合。</target>
-        <note>{Locked="--show-test-results"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results 的值 'all' 或 'none' 不能與任何其他值組合。</target>
+        <note>{Locked="--show-test-results"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionDescription">
         <source>Selects which test outcomes render a per-test result block (with its informative details, stack trace, and captured output) in the terminal.
 Valid values are 'passed', 'failed' (also covers errored, timed out, and canceled tests), 'skipped', 'all', and 'none'. Combine multiple values as a comma- or space-separated list, or by repeating the option; 'all' and 'none' cannot be combined with any other value.
 Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it is 'Normal' or omitted, and 'all' when it is 'Detailed'. An explicit '--show-test-results' always takes precedence over '--output', regardless of the order they are passed in.</source>
-        <target state="translated">選取哪些測試結果會在終端機中顯示每個測試的結果區塊，以及其說明詳細資料、堆疊追蹤和擷取的輸出。
+        <target state="needs-review-translation">選取哪些測試結果會在終端機中顯示每個測試的結果區塊，以及其說明詳細資料、堆疊追蹤和擷取的輸出。
 有效值為 'passed'、'failed' (也包含發生錯誤、逾時和已取消的測試)、'skipped'、'all' 和 'none'。您可以將多個值組合成以逗號或空格分隔的清單，或重複使用此選項；'all' 和 'none' 不能與任何其他值組合。
 當 '--output' 為 'Minimal' 時，預設值為 'failed'；當為 'Normal' 或未指定時，預設值為 'failed' 和 'skipped'；當為 'Detailed' 時，預設值為 'all'。無論傳遞順序為何，明確指定的 '--show-test-results' 一律優先於 '--output'。</target>
-        <note>Do not localize the values {Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}{Locked="'--output'"}{Locked="'Minimal'"}{Locked="'Normal'"}{Locked="'Detailed'"}{Locked="'--show-test-results'"}.</note>
+        <note>Do not localize the values {Locked="'passed'"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}{Locked="--output"}{Locked="Minimal"}{Locked="Normal"}{Locked="Detailed"}{Locked="--show-test-results"}.</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionEmptySelectionInvalidArgument">
         <source>--show-test-results requires at least one value from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results 至少需要一個值，值可為 'passed'、'failed'、'skipped'、'all' 或 'none'。</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results 至少需要一個值，值可為 'passed'、'failed'、'skipped'、'all' 或 'none'。</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalShowTestResultsOptionUnknownValueInvalidArgument">
         <source>--show-test-results expects one or more comma- or space-separated values from 'passed', 'failed', 'skipped', 'all', or 'none'.</source>
-        <target state="translated">--show-test-results 接受一或多個以逗號或空格分隔的值，值可為 'passed'、'failed'、'skipped'、'all' 或 'none'。</target>
-        <note>{Locked="--show-test-results"}{Locked="'passed'"}{Locked="'failed'"}{Locked="'skipped'"}{Locked="'all'"}{Locked="'none'"}</note>
+        <target state="needs-review-translation">--show-test-results 接受一或多個以逗號或空格分隔的值，值可為 'passed'、'failed'、'skipped'、'all' 或 'none'。</target>
+        <note>{Locked="--show-test-results"}{Locked="passed"}{Locked="failed"}{Locked="skipped"}{Locked="all"}{Locked="none"}</note>
       </trans-unit>
       <trans-unit id="TerminalTestReporterDescription">
         <source>Writes test results to terminal.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -485,19 +485,19 @@
   </data>
   <data name="CommandLineVSTestConsoleLoggerReplacement" xml:space="preserve">
     <value>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</value>
-    <comment>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</comment>
+    <comment>{0} is the MTP output verbosity. {Locked=&quot;MTP&quot;}{Locked=&quot;--output {0}&quot;}</comment>
   </data>
   <data name="CommandLineVSTestXPlatCoverageReplacement" xml:space="preserve">
     <value>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</value>
-    <comment>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</comment>
+    <comment>{Locked=&quot;MTP&quot;}{Locked=&quot;--coverage&quot;}{Locked=&quot;Coverlet&quot;}{Locked=&quot;XPlat Code Coverage&quot;}</comment>
   </data>
   <data name="CommandLineVSTestBlameReplacement" xml:space="preserve">
     <value>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</value>
-    <comment>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</comment>
+    <comment>{Locked=&quot;--crashdump&quot;}{Locked=&quot;--hangdump&quot;}{Locked=&quot;MTP&quot;}{Locked=&quot;VSTest&quot;}</comment>
   </data>
   <data name="CommandLineVSTestLoggerGuidance" xml:space="preserve">
     <value>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</value>
-    <comment>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</comment>
+    <comment>{Locked=&quot;MTP&quot;}{Locked=&quot;--report-trx&quot;}{Locked=&quot;--report-html&quot;}{Locked=&quot;--report-junit&quot;}</comment>
   </data>
   <data name="CommandLineVSTestCollectorGuidance" xml:space="preserve">
     <value>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</value>
@@ -509,7 +509,7 @@
   </data>
   <data name="CommandLineUnknownOptionsHint" xml:space="preserve">
     <value>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</value>
-    <comment>{Locked="'--help'"}</comment>
+    <comment>{Locked=&quot;--help&quot;}</comment>
   </data>
   <data name="CommandLineOptionRequiresExtension" xml:space="preserve">
     <value>Option '--{0}' is provided by the '{1}' extension. Add a package reference to use it.</value>
@@ -781,13 +781,13 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
   </data>
   <data name="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage" xml:space="preserve">
     <value>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</value>
-    <comment>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</comment>
+    <comment>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known &apos;ALL APPLICATION PACKAGES&apos; security identifier. {Locked=&quot;S-1-15-2-...&quot;}</comment>
   </data>
   <data name="PlatformCommandLineIgnoreExitCodeOptionDescription" xml:space="preserve">
     <value>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</value>
-    <comment>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</comment>
+    <comment>{Locked=&quot;--ignore-exit-code 8;9&quot;} {Locked=&quot;https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes&quot;}</comment>
   </data>
   <data name="PlatformCommandLineExitOnProcessExitOptionDescription" xml:space="preserve">
     <value>Exit the test process if dependent process exits. PID must be provided.</value>
@@ -879,12 +879,12 @@ For more information about exit codes, see https://learn.microsoft.com/dotnet/co
   </data>
   <data name="PlatformCommandLineTimeoutArgumentErrorMessage" xml:space="preserve">
     <value>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</value>
-    <comment>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</comment>
+    <comment>{Locked=&quot;timeout&quot;}{Locked=&quot;&apos;ms&apos;&quot;}{Locked=&quot;mil(s)&quot;}{Locked=&quot;millisecond(s)&quot;}{Locked=&quot;&apos;s&apos;&quot;}{Locked=&quot;sec(s)&quot;}{Locked=&quot;&apos;second(s)&apos;&quot;}{Locked=&quot;&apos;m&apos;&quot;}{Locked=&quot;min(s)&quot;}{Locked=&quot;minute(s)&quot;}{Locked=&quot;&apos;h&apos;&quot;}{Locked=&quot;hour(s)&quot;}{Locked=&quot;&apos;d&apos;&quot;}{Locked=&quot;day(s)&quot;}{Locked=&quot;500ms&quot;}{Locked=&quot;5400s&quot;}{Locked=&quot;90m&quot;}{Locked=&quot;1.5h&quot;}{Locked=&quot;1d&quot;}</comment>
   </data>
   <data name="PlatformCommandLineTimeoutOptionDescription" xml:space="preserve">
     <value>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</value>
-    <comment>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</comment>
+    <comment>{Locked=&quot;&apos;ms&apos;&quot;}{Locked=&quot;mil(s)&quot;}{Locked=&quot;millisecond(s)&quot;}{Locked=&quot;&apos;s&apos;&quot;}{Locked=&quot;sec(s)&quot;}{Locked=&quot;&apos;second(s)&apos;&quot;}{Locked=&quot;&apos;m&apos;&quot;}{Locked=&quot;min(s)&quot;}{Locked=&quot;minute(s)&quot;}{Locked=&quot;&apos;h&apos;&quot;}{Locked=&quot;hour(s)&quot;}{Locked=&quot;&apos;d&apos;&quot;}{Locked=&quot;day(s)&quot;}{Locked=&quot;500ms&quot;}{Locked=&quot;5400s&quot;}{Locked=&quot;90m&quot;}{Locked=&quot;1.5h&quot;}{Locked=&quot;1d&quot;}</comment>
   </data>
   <data name="LoggerFactoryNotReady" xml:space="preserve">
     <value>The ILoggerFactory has not been built yet.</value>
@@ -1063,7 +1063,7 @@ Valid values are 'allow-skipped' (the default) which counts skipped tests as run
   </data>
   <data name="PlatformCommandLineEnableDynamicExtensionsOptionDescription" xml:space="preserve">
 <value>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</value>
-    <comment>{Locked="'*.testingplatformextensions.json'"}</comment>
+    <comment>{Locked=&quot;*.testingplatformextensions.json&quot;}</comment>
   </data>
   <data name="DynamicExtensionsLoadedHeader" xml:space="preserve">
     <value>Dynamically loaded test platform extensions ({0}):</value>
@@ -1139,11 +1139,11 @@ Valid values are 'allow-skipped' (the default) which counts skipped tests as run
   </data>
   <data name="DynamicExtensionHookNotFoundErrorMessage" xml:space="preserve">
     <value>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</value>
-    <comment>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</comment>
+    <comment>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked=&quot;public static void&quot;}{Locked=&quot;ITestApplicationBuilder&quot;}{Locked=&quot;string[]&quot;}</comment>
   </data>
   <data name="DynamicExtensionHookMustReturnVoidErrorMessage" xml:space="preserve">
     <value>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</value>
-    <comment>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</comment>
+    <comment>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked=&quot;void&quot;}</comment>
   </data>
   <data name="DynamicExtensionDuplicateIdConflictErrorMessage" xml:space="preserve">
     <value>The extension id '{0}' is declared twice with different content: '{1}' in the extension manifest '{2}' and '{3}' in the extension manifest '{4}'. Ids must identify the same extension, otherwise one declaration would silently replace the other.</value>
@@ -1163,10 +1163,10 @@ Valid values are 'allow-skipped' (the default) which counts skipped tests as run
   </data>
   <data name="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage" xml:space="preserve">
     <value>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</value>
-    <comment>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</comment>
+    <comment>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked=&quot;async void&quot;}</comment>
   </data>
   <data name="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage" xml:space="preserve">
     <value>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</value>
-    <comment>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</comment>
+    <comment>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked=&quot;false&quot;}</comment>
   </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Spuštěním --help zobrazíte možnosti zaregistrované touto testovací aplikací. Pokud tato možnost patří k rozšíření, ujistěte se, že se odkazuje na jeho balíček a že je rozšíření zaregistrované.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Spuštěním --help zobrazíte možnosti zaregistrované touto testovací aplikací. Pokud tato možnost patří k rozšíření, ujistěte se, že se odkazuje na jeho balíček a že je rozšíření zaregistrované.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">Místo toho použijte '--crashdump' nebo '--hangdump', případně obojí. MTP odděluje diagnostiku chybových ukončení a zablokování, takže za kolektor blame nástroje VSTest neexistuje náhrada jedna ku jedné.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">Místo toho použijte '--crashdump' nebo '--hangdump', případně obojí. MTP odděluje diagnostiku chybových ukončení a zablokování, takže za kolektor blame nástroje VSTest neexistuje náhrada jedna ku jedné.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Pokud chcete dosáhnout srovnatelné úrovně podrobností výstupu konzoly, použijte '--output {0}'. Výstup konzoly MTP je nakonfigurovaný jinak, takže nejde o přesnou náhradu.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Pokud chcete dosáhnout srovnatelné úrovně podrobností výstupu konzoly, použijte '--output {0}'. Výstup konzoly MTP je nakonfigurovaný jinak, takže nejde o přesnou náhradu.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP používá možnosti specifické pro jednotlivé reportéry, například '--report-trx', '--report-html' a '--report-junit'. Informace o příslušné možnosti MTP najdete v dokumentaci k rozšíření reportéru.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP používá možnosti specifické pro jednotlivé reportéry, například '--report-trx', '--report-html' a '--report-junit'. Informace o příslušné možnosti MTP najdete v dokumentaci k rozšíření reportéru.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">Pro pokrytí kódu v MTP použijte '--coverage'. Nejde o přímou náhradu kolektoru 'XPlat Code Coverage' z frameworku Coverlet.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">Pro pokrytí kódu v MTP použijte '--coverage'. Nejde o přímou náhradu kolektoru 'XPlat Code Coverage' z frameworku Coverlet.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">Háček rozšíření {0}.{1} ze sestavení {2}, který je deklarovaný v manifestu rozšíření {3}, je deklarovaný jako „async void“. Platforma volá háček synchronně, takže by se vrátila při prvním čekání: vše, co se zaregistruje po tomto bodu, by se zahodilo ve vlastním nastavení testovací aplikace a všechny chyby by se ztratily. Nastavte háček jako synchronní.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">Háček rozšíření {0}.{1} ze sestavení {2}, který je deklarovaný v manifestu rozšíření {3}, je deklarovaný jako „async void“. Platforma volá háček synchronně, takže by se vrátila při prvním čekání: vše, co se zaregistruje po tomto bodu, by se zahodilo ve vlastním nastavení testovací aplikace a všechny chyby by se ztratily. Nastavte háček jako synchronní.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">Háček rozšíření {0}.{1} ze sestavení {2}, který je deklarovaný v manifestu rozšíření {3}, vrací {4}, ale musí vracet „void“. Platforma volá háček synchronně, takže se nikdy nezpozoruje návratová hodnota. Konkrétně vrácená úloha by se nikdy neočekávaná a jeho registrace a selhání by se ztratily.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">Háček rozšíření {0}.{1} ze sestavení {2}, který je deklarovaný v manifestu rozšíření {3}, vrací {4}, ale musí vracet „void“. Platforma volá háček synchronně, takže se nikdy nezpozoruje návratová hodnota. Konkrétně vrácená úloha by se nikdy neočekávaná a jeho registrace a selhání by se ztratily.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">Typ {0} v sestavení '{1}, které je deklarováno v manifestu rozšíření {2}, nezpřístupňuje metodu „public static void“ s názvem {3}, která přijímá „ITestApplicationBuilder“ a „string[]“.</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">Typ {0} v sestavení '{1}, které je deklarováno v manifestu rozšíření {2}, nezpřístupňuje metodu „public static void“ s názvem {3}, která přijímá „ITestApplicationBuilder“ a „string[]“.</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">Manifest rozšíření {0} deklaruje načtení rozšíření, ale aktuální modul runtime nepodporuje dynamické načítání sestavení (například při publikování s nativním AOT). Nastavte vlastnost {1} každého rozšíření na „false“, odeberte manifest nebo odeberte {2} z příkazového řádku.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">Manifest rozšíření {0} deklaruje načtení rozšíření, ale aktuální modul runtime nepodporuje dynamické načítání sestavení (například při publikování s nativním AOT). Nastavte vlastnost {1} každého rozšíření na „false“, odeberte manifest nebo odeberte {2} z příkazového řádku.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Volitelně přijímá hodnotu „text“ (výchozí výstup čitelný pro člov�
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Povolte načítání rozšíření testovací platformy deklarovaných manifesty „*.testingplatformextensions.json“ nalezenými vedle testovací aplikace. Ve výchozím nastavení je to zakázané.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Povolte načítání rozšíření testovací platformy deklarovaných manifesty „*.testingplatformextensions.json“ nalezenými vedle testovací aplikace. Ve výchozím nastavení je to zakázané.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Volitelně přijímá hodnotu „text“ (výchozí výstup čitelný pro člov�
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">Neohlašujte neúspěšnou ukončovací hodnotu zadaných ukončovacích kódů.
+        <target state="needs-review-translation">Neohlašujte neúspěšnou ukončovací hodnotu zadaných ukončovacích kódů.
 Například „--ignore-exit-code 8;9“ ignoruje ukončovací kódy 8 a 9 a v těchto případech vrátí hodnotu 0.
 Další informace o ukončovacích kódech najdete na https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1051,14 +1051,14 @@ Výchozí hodnota je TestResults v adresáři, který obsahuje testovací aplika
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Přečtěte si další informace o telemetrii Microsoft Testing Platform: https:
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">Spouštěč testovacího hostitele {0} (UID: {1}) požádal o autorizaci identity zabezpečení {2} v připojení ke kontroleru testovacího hostitele, ale autorizovat je možné jen identitu jedné aplikace v sandboxu (ve Windows identifikátor zabezpečení ve tvaru 'S-1-15-2-...'). Uživatelům, skupinám ani univerzálnímu identifikátoru zabezpečení {3} se přístup nikdy neuděluje.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">Spouštěč testovacího hostitele {0} (UID: {1}) požádal o autorizaci identity zabezpečení {2} v připojení ke kontroleru testovacího hostitele, ale autorizovat je možné jen identitu jedné aplikace v sandboxu (ve Windows identifikátor zabezpečení ve tvaru 'S-1-15-2-...'). Uživatelům, skupinám ani univerzálnímu identifikátoru zabezpečení {3} se přístup nikdy neuděluje.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Führen Sie '--help' aus, um die von dieser Testanwendung registrierten Optionen anzuzeigen. Wenn die Option zu einer Erweiterung gehört, stellen Sie sicher, dass das zugehörige Paket als Verweis eingebunden ist und die Erweiterung registriert ist.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Führen Sie '--help' aus, um die von dieser Testanwendung registrierten Optionen anzuzeigen. Wenn die Option zu einer Erweiterung gehört, stellen Sie sicher, dass das zugehörige Paket als Verweis eingebunden ist und die Erweiterung registriert ist.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">Verwenden Sie stattdessen „--crashdump“ und/oder „--hangdump“. MTP trennt Diagnosen für Abstürze und Hänger, daher gibt es keinen direkten Ersatz für den VSTest-Blame-Collector.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">Verwenden Sie stattdessen „--crashdump“ und/oder „--hangdump“. MTP trennt Diagnosen für Abstürze und Hänger, daher gibt es keinen direkten Ersatz für den VSTest-Blame-Collector.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Verwenden Sie „--output {0}“, um eine vergleichbare Ausführlichkeit der Konsole zu erzielen. Die MTP-Konsolenausgabe ist anders konfiguriert, sodass dies kein exakter Ersatz ist.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Verwenden Sie „--output {0}“, um eine vergleichbare Ausführlichkeit der Konsole zu erzielen. Die MTP-Konsolenausgabe ist anders konfiguriert, sodass dies kein exakter Ersatz ist.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP verwendet reporterspezifische Optionen wie „--report-trx“, „--report-html“ und „--report-junit“. Die MTP-Option finden Sie in der Dokumentation der Reportererweiterung.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP verwendet reporterspezifische Optionen wie „--report-trx“, „--report-html“ und „--report-junit“. Die MTP-Option finden Sie in der Dokumentation der Reportererweiterung.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">Verwenden Sie für MTP-Code Coverage „--coverage“. Dies ist kein transparenter Ersatz für den XPlat Code Coverage-Collector von Coverlet.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">Verwenden Sie für MTP-Code Coverage „--coverage“. Dies ist kein transparenter Ersatz für den XPlat Code Coverage-Collector von Coverlet.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">Der Erweiterungshook „{0}.{1}“ aus der Assembly „{2}“, die im Erweiterungsmanifest „{3}“ deklariert ist, ist als „async void“ deklariert. Die Plattform ruft den Hook synchron auf, sodass er beim ersten Await-Vorgang zurückgegeben wird: Alles, was sie nach diesem Punkt registriert, würde das Setup der Testanwendung als Race ausführen, und jeder Fehler würde verloren gehen. Machen Sie den Hook synchron.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">Der Erweiterungshook „{0}.{1}“ aus der Assembly „{2}“, die im Erweiterungsmanifest „{3}“ deklariert ist, ist als „async void“ deklariert. Die Plattform ruft den Hook synchron auf, sodass er beim ersten Await-Vorgang zurückgegeben wird: Alles, was sie nach diesem Punkt registriert, würde das Setup der Testanwendung als Race ausführen, und jeder Fehler würde verloren gehen. Machen Sie den Hook synchron.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">Der Erweiterungshook „{0}.{1}“ aus der Assembly „{2}“, die im Erweiterungsmanifest „{3}“ deklariert ist, gibt „{4}“ zurück, muss aber „void“ zurückgeben. Die Plattform ruft den Hook synchron auf, sodass nie ein Rückgabewert beobachtet wird. insbesondere auf eine zurückgegebene Aufgabe wird nie gewartet, und ihre Registrierungen und Fehler gehen verloren.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">Der Erweiterungshook „{0}.{1}“ aus der Assembly „{2}“, die im Erweiterungsmanifest „{3}“ deklariert ist, gibt „{4}“ zurück, muss aber „void“ zurückgeben. Die Plattform ruft den Hook synchron auf, sodass nie ein Rückgabewert beobachtet wird. insbesondere auf eine zurückgegebene Aufgabe wird nie gewartet, und ihre Registrierungen und Fehler gehen verloren.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">Der Typ „{0}“ in der Assembly „{1}“, der im Erweiterungsmanifest „{2}“ deklariert ist, macht keine „public static void“-Methode namens „{3}“ verfügbar, die einen „ITestApplicationBuilder“ und einen „string[]“ verwendet.</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">Der Typ „{0}“ in der Assembly „{1}“, der im Erweiterungsmanifest „{2}“ deklariert ist, macht keine „public static void“-Methode namens „{3}“ verfügbar, die einen „ITestApplicationBuilder“ und einen „string[]“ verwendet.</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">Das Erweiterungsmanifest „{0}“ deklariert Erweiterungen zum Laden, aber die aktuelle Runtime unterstützt das dynamische Laden von Assemblys nicht (z. B. bei Veröffentlichung mit nativem AOT). Legen Sie die Eigenschaft „{1}“ jeder Erweiterung auf „false“ fest, entfernen Sie das Manifest, oder entfernen Sie „{2}“ aus der Befehlszeile.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">Das Erweiterungsmanifest „{0}“ deklariert Erweiterungen zum Laden, aber die aktuelle Runtime unterstützt das dynamische Laden von Assemblys nicht (z. B. bei Veröffentlichung mit nativem AOT). Legen Sie die Eigenschaft „{1}“ jeder Erweiterung auf „false“ fest, entfernen Sie das Manifest, oder entfernen Sie „{2}“ aus der Befehlszeile.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Akzeptiert optional „text“ (die standardmäsige lesbare Ausgabe) oder „jso
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Aktivieren Sie das Laden von Testplattformerweiterungen, die von den Manifesten „*.testingplatformextensions.json“ deklariert wurden, die neben der Testanwendung gefunden wurden. Standardmäßig deaktiviert.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Aktivieren Sie das Laden von Testplattformerweiterungen, die von den Manifesten „*.testingplatformextensions.json“ deklariert wurden, die neben der Testanwendung gefunden wurden. Standardmäßig deaktiviert.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Akzeptiert optional „text“ (die standardmäsige lesbare Ausgabe) oder „jso
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">Keinen nicht erfolgreichen Beendigungswert für die angegebenen Exitcodes melden.
+        <target state="needs-review-translation">Keinen nicht erfolgreichen Beendigungswert für die angegebenen Exitcodes melden.
 Beispiel: „--ignore-exit-code 8;9“ ignoriert die Exitcodes 8 und 9 und gibt in diesen Fällen 0 zurück.
 Weitere Informationen zu Exitcodes finden Sie unter https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1051,14 +1051,14 @@ Der Standardwert ist "TestResults" im Verzeichnis, das die Testanwendung enthäl
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">Eine globale Testausführungszeitüberschreitung.
+        <target state="needs-review-translation">Eine globale Testausführungszeitüberschreitung.
 Verwendet ein Argument als Zeitwert mit einem expliziten Einheitensuffix. Akzeptierte Suffixe sind 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', z. B. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Weitere Informationen zu Microsoft Testing Platform-Telemetriedaten: https://aka
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">Der Testhost-Launcher „{0}“ (UID: {1}) hat angefordert, die Sicherheitsidentität „{2}“ für die Testhostcontrollerverbindung zu autorisieren. Es kann jedoch nur die Identität einer einzelnen Sandbox-App autorisiert werden (unter Windows eine Sicherheits-ID im Format „S-1-15-2-...“). Benutzern, Gruppen und dem Sammelbezeichner „{3}“ wird niemals Zugriff gewährt.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">Der Testhost-Launcher „{0}“ (UID: {1}) hat angefordert, die Sicherheitsidentität „{2}“ für die Testhostcontrollerverbindung zu autorisieren. Es kann jedoch nur die Identität einer einzelnen Sandbox-App autorisiert werden (unter Windows eine Sicherheits-ID im Format „S-1-15-2-...“). Benutzern, Gruppen und dem Sammelbezeichner „{3}“ wird niemals Zugriff gewährt.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Ejecute "--help" para ver las opciones registradas por esta aplicación de prueba. Si la opción pertenece a una extensión, asegúrese de que se hace referencia a su paquete y de que la extensión está registrada.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Ejecute "--help" para ver las opciones registradas por esta aplicación de prueba. Si la opción pertenece a una extensión, asegúrese de que se hace referencia a su paquete y de que la extensión está registrada.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">Use '--crashdump' y/o '--hangdump' en su lugar. MTP separa los diagnósticos de bloqueos y cuelgues, por lo que no existe un reemplazo uno a uno para el recopilador de VSTest de errores.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">Use '--crashdump' y/o '--hangdump' en su lugar. MTP separa los diagnósticos de bloqueos y cuelgues, por lo que no existe un reemplazo uno a uno para el recopilador de VSTest de errores.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Para un nivel de detalle de consola comparable, use '--output {0}'. La salida de consola de MTP se configura de forma diferente, por lo que no se trata de un reemplazo exacto.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Para un nivel de detalle de consola comparable, use '--output {0}'. La salida de consola de MTP se configura de forma diferente, por lo que no se trata de un reemplazo exacto.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP usa opciones específicas del informador, como '--report-trx', '--report-html' y '--report-junit'. Consulte la documentación de la extensión del informador para conocer su opción de MTP.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP usa opciones específicas del informador, como '--report-trx', '--report-html' y '--report-junit'. Consulte la documentación de la extensión del informador para conocer su opción de MTP.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">Para la cobertura de código en MTP, use '--coverage'. Este no es un reemplazo transparente del recopilador 'XPlat Code Coverage' de Coverlet.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">Para la cobertura de código en MTP, use '--coverage'. Este no es un reemplazo transparente del recopilador 'XPlat Code Coverage' de Coverlet.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">El enlace de extensión "{0}.{1}" del ensamblado "{2}" declarado en el manifiesto de extensión "{3}" se declara como "async void". La plataforma invoca el enlace de forma sincrónica, por lo que devolvería en su primera espera: cualquier cosa que registre después de ese punto ejecutaría la propia configuración de la aplicación de prueba y se perdería cualquier error. Haga que el enlace sea sincrónico.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">El enlace de extensión "{0}.{1}" del ensamblado "{2}" declarado en el manifiesto de extensión "{3}" se declara como "async void". La plataforma invoca el enlace de forma sincrónica, por lo que devolvería en su primera espera: cualquier cosa que registre después de ese punto ejecutaría la propia configuración de la aplicación de prueba y se perdería cualquier error. Haga que el enlace sea sincrónico.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">El enlace de extensión "{0}.{1}" del ensamblado "{2}" declarado en el manifiesto de extensión "{3}" devuelve "{4}", pero debe devolver "void". La plataforma invoca el gancho de forma síncrona, por lo que nunca se observa ningún valor devuelto; en particular, una tarea devuelta nunca se esperaría, y sus registros y errores se perderían.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">El enlace de extensión "{0}.{1}" del ensamblado "{2}" declarado en el manifiesto de extensión "{3}" devuelve "{4}", pero debe devolver "void". La plataforma invoca el gancho de forma síncrona, por lo que nunca se observa ningún valor devuelto; en particular, una tarea devuelta nunca se esperaría, y sus registros y errores se perderían.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">El tipo "{0}" del ensamblado "{1}" declarado en el manifiesto de extensión "{2}" no expone un método "public static void" denominado "{3}" que tome "ITestApplicationBuilder" y "string[]".</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">El tipo "{0}" del ensamblado "{1}" declarado en el manifiesto de extensión "{2}" no expone un método "public static void" denominado "{3}" que tome "ITestApplicationBuilder" y "string[]".</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">El manifiesto de extensión "{0}" declara las extensiones que se van a cargar, pero el tiempo de ejecución actual no admite la carga dinámica de ensamblados (por ejemplo, cuando se publica con AOT nativo). Establezca la propiedad "{1}" de cada extensión en "false", quite el manifiesto o quite "{2}" de la línea de comandos.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">El manifiesto de extensión "{0}" declara las extensiones que se van a cargar, pero el tiempo de ejecución actual no admite la carga dinámica de ensamblados (por ejemplo, cuando se publica con AOT nativo). Establezca la propiedad "{1}" de cada extensión en "false", quite el manifiesto o quite "{2}" de la línea de comandos.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Opcionalmente, acepta "text" (la salida legible por el usuario predeterminada) o
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Habilite la carga de extensiones de plataforma de prueba declaradas por los manifiestos "*.testingplatformextensions.json" que se encuentran junto a la aplicación de prueba. Esta opción está deshabilitada de forma predeterminada.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Habilite la carga de extensiones de plataforma de prueba declaradas por los manifiestos "*.testingplatformextensions.json" que se encuentran junto a la aplicación de prueba. Esta opción está deshabilitada de forma predeterminada.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Opcionalmente, acepta "text" (la salida legible por el usuario predeterminada) o
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">No informe de un valor de salida no correcto para los códigos de salida especificados.
+        <target state="needs-review-translation">No informe de un valor de salida no correcto para los códigos de salida especificados.
 Por ejemplo, '--ignore-exit-code 8;9' omite los códigos de salida 8 y 9 y devuelve 0 en esos casos.
 Para obtener más información sobre los códigos de salida, consulte https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1051,14 +1051,14 @@ El valor predeterminado es TestResults en el directorio que contiene la aplicaci
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Más información sobre la telemetría de la Plataforma de pruebas de Microsoft:
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">El iniciador de host de prueba "{0}" (UID: {1}) solicitó autorizar la identidad de seguridad "{2}" en la conexión del controlador host de prueba, pero solo se puede autorizar la identidad de una sola aplicación de espacio aislado (en Windows, un identificador de seguridad con el formato 'S-1-15-2-...'). Nunca se concede acceso a usuarios, grupos ni al identificador de seguridad "{3}" de uso general.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">El iniciador de host de prueba "{0}" (UID: {1}) solicitó autorizar la identidad de seguridad "{2}" en la conexión del controlador host de prueba, pero solo se puede autorizar la identidad de una sola aplicación de espacio aislado (en Windows, un identificador de seguridad con el formato 'S-1-15-2-...'). Nunca se concede acceso a usuarios, grupos ni al identificador de seguridad "{3}" de uso general.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Exécutez '--help' pour voir les options enregistrées par cette application de test. Si l’option appartient à une extension, vérifiez que son package est référencé et que l’extension est inscrite.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Exécutez '--help' pour voir les options enregistrées par cette application de test. Si l’option appartient à une extension, vérifiez que son package est référencé et que l’extension est inscrite.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">Utilisez « --crashdump » et/ou « --hangdump » à la place. MTP sépare les diagnostics de plantage et de blocage, il n’existe donc pas de remplacement un à un du collecteur de défaillance VSTest.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">Utilisez « --crashdump » et/ou « --hangdump » à la place. MTP sépare les diagnostics de plantage et de blocage, il n’existe donc pas de remplacement un à un du collecteur de défaillance VSTest.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Pour obtenir une verbosité de console comparable, utilisez « --output {0} ». La sortie de la console MTP est configurée différemment, donc il ne s’agit pas d’un remplacement exact.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Pour obtenir une verbosité de console comparable, utilisez « --output {0} ». La sortie de la console MTP est configurée différemment, donc il ne s’agit pas d’un remplacement exact.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP utilise des options spécifiques au rapporteur, telles que « --report-trx », « --report-html » et « --report-junit ». Consultez la documentation de l’extension du rapporteur pour connaître son option MTP.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP utilise des options spécifiques au rapporteur, telles que « --report-trx », « --report-html » et « --report-junit ». Consultez la documentation de l’extension du rapporteur pour connaître son option MTP.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">Pour la couverture du code MTP, utilisez « --coverage ». Il ne s’agit pas d’un remplacement transparent du collecteur « XPlat Code Coverage » de Coverlet.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">Pour la couverture du code MTP, utilisez « --coverage ». Il ne s’agit pas d’un remplacement transparent du collecteur « XPlat Code Coverage » de Coverlet.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">Le hook d’extension '{0}.{1}' de l’assembly '{2}', annoncé dans le manifeste d’extension '{3}', est déclaré en 'async void'. La plateforme appelle le hook de manière synchrone. Il reviendra donc à son premier await : tout ce qu’il enregistre après ce point entrera en concurrence avec la configuration de l’application de test, et toute erreur sera perdue. Rendez le hook synchrone.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">Le hook d’extension '{0}.{1}' de l’assembly '{2}', annoncé dans le manifeste d’extension '{3}', est déclaré en 'async void'. La plateforme appelle le hook de manière synchrone. Il reviendra donc à son premier await : tout ce qu’il enregistre après ce point entrera en concurrence avec la configuration de l’application de test, et toute erreur sera perdue. Rendez le hook synchrone.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">Le hook d’extension '{0}.{1}' de l’assembly '{2}', annoncé dans le manifeste d’extension '{3}', renvoie '{4}' alors qu’il retourne 'void'. La plateforme appelle le crochet de manière synchrone, donc aucune valeur de retour n’est jamais observée. En particulier, une tâche retournée ne sera jamais attendue et ses enregistrements ainsi que ses erreurs seront perdus.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">Le hook d’extension '{0}.{1}' de l’assembly '{2}', annoncé dans le manifeste d’extension '{3}', renvoie '{4}' alors qu’il retourne 'void'. La plateforme appelle le crochet de manière synchrone, donc aucune valeur de retour n’est jamais observée. En particulier, une tâche retournée ne sera jamais attendue et ses enregistrements ainsi que ses erreurs seront perdus.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">Le type '{0}' de l’assembly '{1}' déclaré dans le manifeste d’extension '{2}' n’expose pas de méthode 'public static void' nommée '{3}' prenant un 'ITestApplicationBuilder' et un 'string[]'.</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">Le type '{0}' de l’assembly '{1}' déclaré dans le manifeste d’extension '{2}' n’expose pas de méthode 'public static void' nommée '{3}' prenant un 'ITestApplicationBuilder' et un 'string[]'.</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">Le manifeste d’extension '{0}' déclare des extensions à charger, mais le runtime actuel ne prend pas en charge le chargement dynamique d’assemblys (par exemple lorsqu’il est publié avec AOT natif). Définissez la propriété '{1}' de chaque extension sur 'false', supprimez le manifeste ou éliminez '{2}' de la ligne de commande.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">Le manifeste d’extension '{0}' déclare des extensions à charger, mais le runtime actuel ne prend pas en charge le chargement dynamique d’assemblys (par exemple lorsqu’il est publié avec AOT natif). Définissez la propriété '{1}' de chaque extension sur 'false', supprimez le manifeste ou éliminez '{2}' de la ligne de commande.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Accepte éventuellement « text » (sortie lisible par l’humain par défaut)
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Activez le chargement des extensions de plateforme de test déclarées par des manifestes '*.testingplatformextensions.json' trouvés à côté de l’application de test. Cette option est désactivée par défaut.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Activez le chargement des extensions de plateforme de test déclarées par des manifestes '*.testingplatformextensions.json' trouvés à côté de l’application de test. Cette option est désactivée par défaut.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Accepte éventuellement « text » (sortie lisible par l’humain par défaut)
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">Ne signalez pas de valeur de sortie non correcte pour les codes de sortie spécifiés.
+        <target state="needs-review-translation">Ne signalez pas de valeur de sortie non correcte pour les codes de sortie spécifiés.
 Par exemple, '--ignore-exit-code 8;9' ignore les codes de sortie 8 et 9 et renvoie 0 dans ces cas.
 Pour découvrir plus d’informations sur les codes de sortie, consultez https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1050,15 +1050,15 @@ La valeur par défaut est TestResults dans le répertoire qui contient l’appli
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">L’option « timeout » doit avoir un argument correspondant à une valeur de temps avec un suffixe d’unité explicite et une valeur numérique positive dans la plage prise en charge (jusqu’à environ 49,7 jours). Les suffixes acceptés sont 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' et 'd'/'day(s)', par exemple '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <target state="needs-review-translation">L’option « timeout » doit avoir un argument correspondant à une valeur de temps avec un suffixe d’unité explicite et une valeur numérique positive dans la plage prise en charge (jusqu’à environ 49,7 jours). Les suffixes acceptés sont 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' et 'd'/'day(s)', par exemple '500ms', '5400s', '90m', '1.5h', '1d'.</target>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">Délai global d’exécution du test.
+        <target state="needs-review-translation">Délai global d’exécution du test.
 Prend un argument correspondant à une valeur de temps avec un suffixe d’unité explicite. Les suffixes acceptés sont 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' et 'd'/'day(s)', par exemple '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ En savoir plus sur la télémétrie de la plateforme de tests Microsoft : https:
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">Le lanceur d’hôte de test « {0} » (UID : {1}) a demandé à autoriser l’identité de sécurité « {2} » sur la connexion du contrôleur d’hôte de test, mais seule l’identité d’une application isolée en bac à sable peut être autorisée (sous Windows, identificateur de sécurité au format « S-1-15-2-... »). Les utilisateurs, les groupes et l’identificateur de sécurité « {3} » fourre-tout ne bénéficient jamais d’un accès.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">Le lanceur d’hôte de test « {0} » (UID : {1}) a demandé à autoriser l’identité de sécurité « {2} » sur la connexion du contrôleur d’hôte de test, mais seule l’identité d’une application isolée en bac à sable peut être autorisée (sous Windows, identificateur de sécurité au format « S-1-15-2-... »). Les utilisateurs, les groupes et l’identificateur de sécurité « {3} » fourre-tout ne bénéficient jamais d’un accès.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Eseguire '--help' per visualizzare le opzioni registrate da questa applicazione di test. Se l'opzione appartiene a un'estensione, assicurarsi che sia fatto riferimento al relativo pacchetto e che l'estensione sia registrata.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Eseguire '--help' per visualizzare le opzioni registrate da questa applicazione di test. Se l'opzione appartiene a un'estensione, assicurarsi che sia fatto riferimento al relativo pacchetto e che l'estensione sia registrata.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">In alternativa, usare '--crashdump' e/o '--hangdump'. MTP separa le diagnostiche di crash e hang, quindi non esiste un sostituto uno-a-uno per l'agente di raccolta Blame di VSTest.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">In alternativa, usare '--crashdump' e/o '--hangdump'. MTP separa le diagnostiche di crash e hang, quindi non esiste un sostituto uno-a-uno per l'agente di raccolta Blame di VSTest.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Per un livello di dettaglio paragonabile a quello della console, usa '--output {0}'. L'output della console MTP è configurato in modo diverso, quindi non si tratta di una sostituzione esatta.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Per un livello di dettaglio paragonabile a quello della console, usa '--output {0}'. L'output della console MTP è configurato in modo diverso, quindi non si tratta di una sostituzione esatta.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP usa opzioni specifiche del reporter, come '--report-trx', '--report-html', and '--report-junit'. Consultare la documentazione dell'estensione del reporter per l'opzione MTP corrispondente.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP usa opzioni specifiche del reporter, come '--report-trx', '--report-html', and '--report-junit'. Consultare la documentazione dell'estensione del reporter per l'opzione MTP corrispondente.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">Per la code coverage MTP, usare '--coverage'. Questa non è una sostituzione trasparente dell'agente di raccolta 'XPlat Code Coverage' di Coverlet.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">Per la code coverage MTP, usare '--coverage'. Questa non è una sostituzione trasparente dell'agente di raccolta 'XPlat Code Coverage' di Coverlet.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">L'hook dell'estensione '{0}.{1}' dall'assembly '{2}' dichiarato nel manifesto dell'estensione '{3}' è dichiarato come 'async void'. La piattaforma esegue l'hook in modalità sincrona, pertanto restituirebbe il valore al primo await: tutto ciò che viene registrato successivamente verrebbe a interferire con la configurazione dell'applicazione di test, e gli eventuali errori non verrebbero rilevati. Rendi l'hook sincrono.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">L'hook dell'estensione '{0}.{1}' dall'assembly '{2}' dichiarato nel manifesto dell'estensione '{3}' è dichiarato come 'async void'. La piattaforma esegue l'hook in modalità sincrona, pertanto restituirebbe il valore al primo await: tutto ciò che viene registrato successivamente verrebbe a interferire con la configurazione dell'applicazione di test, e gli eventuali errori non verrebbero rilevati. Rendi l'hook sincrono.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">L'hook dell'estensione '{0}.{1}' dall'assembly '{2}' dichiarato nel manifesto dell'estensione '{3}' restituisce '{4}' ma deve restituire 'void'. La piattaforma richiama l'hook in modo sincrono, per cui un valore restituito non viene mai rilevato; un'attività restituita, in particolare, non verrebbe mai messo in attesa e le relative registrazioni ed errori andrebbero persi.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">L'hook dell'estensione '{0}.{1}' dall'assembly '{2}' dichiarato nel manifesto dell'estensione '{3}' restituisce '{4}' ma deve restituire 'void'. La piattaforma richiama l'hook in modo sincrono, per cui un valore restituito non viene mai rilevato; un'attività restituita, in particolare, non verrebbe mai messo in attesa e le relative registrazioni ed errori andrebbero persi.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">Il tipo '{0}' nell'assembly '{1}' dichiarato nel manifesto dell'estensione '{2}' non espone un metodo 'public static void' denominato '{3}' che accetta un 'ITestApplicationBuilder' e un 'string[]'.</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">Il tipo '{0}' nell'assembly '{1}' dichiarato nel manifesto dell'estensione '{2}' non espone un metodo 'public static void' denominato '{3}' che accetta un 'ITestApplicationBuilder' e un 'string[]'.</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">Il manifesto dell'estensione '{0}' dichiara estensioni da caricare, ma il runtime corrente non supporta il caricamento dinamico degli assembly (ad esempio quando viene pubblicato con AOT nativo). Impostare la proprietà '{1}' di ogni estensione su 'false', rimuovere il manifesto oppure rimuovere '{2}' dalla riga di comando.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">Il manifesto dell'estensione '{0}' dichiara estensioni da caricare, ma il runtime corrente non supporta il caricamento dinamico degli assembly (ad esempio quando viene pubblicato con AOT nativo). Impostare la proprietà '{1}' di ogni estensione su 'false', rimuovere il manifesto oppure rimuovere '{2}' dalla riga di comando.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Facoltativamente accetta ''text'' (output leggibile predefinito) o ''json'' per 
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Abilitare il caricamento delle estensioni della piattaforma di test dichiarate nei manifesti '*.testingplatformextensions.json' trovati accanto all'applicazione di test. Proprietà è disabilitata per impostazione predefinita.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Abilitare il caricamento delle estensioni della piattaforma di test dichiarate nei manifesti '*.testingplatformextensions.json' trovati accanto all'applicazione di test. Proprietà è disabilitata per impostazione predefinita.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Facoltativamente accetta ''text'' (output leggibile predefinito) o ''json'' per 
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">Non segnalare un valore di uscita non riuscito per i codici di uscita specificati.
+        <target state="needs-review-translation">Non segnalare un valore di uscita non riuscito per i codici di uscita specificati.
 Ad esempio, '--ignore-exit-code 8;9' ignora i codici di uscita 8 e 9 e restituisce 0 in tali casi.
 Per altre informazioni sui codici di uscita, vedere https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1050,15 +1050,15 @@ L’impostazione predefinita è TestResults nella directory che contiene l'appli
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">L'opzione 'timeout' richiede un argomento costituito da un valore temporale con un suffisso di unità esplicito e un valore numerico positivo compreso nell'intervallo supportato (fino a circa 49,7 giorni). I suffissi accettati sono 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' e 'd'/'day(s)', ad esempio '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <target state="needs-review-translation">L'opzione 'timeout' richiede un argomento costituito da un valore temporale con un suffisso di unità esplicito e un valore numerico positivo compreso nell'intervallo supportato (fino a circa 49,7 giorni). I suffissi accettati sono 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' e 'd'/'day(s)', ad esempio '500ms', '5400s', '90m', '1.5h', '1d'.</target>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">Timeout globale per l'esecuzione dei test.
+        <target state="needs-review-translation">Timeout globale per l'esecuzione dei test.
 Accetta un argomento come valore di ora con un suffisso di unità esplicito. I suffissi accettati sono 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' e 'd'/'day(s)', ad esempio '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Altre informazioni sulla telemetria della piattaforma di test Microsoft: https:/
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">Il launcher dell'host di test "{0}" (UID: {1}) ha richiesto l'autorizzazione dell'identità di sicurezza "{2}" sulla connessione al controller dell'host di test, ma è possibile autorizzare solo l'identità di una singola applicazione in modalità sandbox (in Windows, un identificatore di sicurezza nel formato 'S-1-15-2-...'). Agli utenti, ai gruppi e all'identificatore di sicurezza generico "{3}" non viene mai concesso l'accesso.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">Il launcher dell'host di test "{0}" (UID: {1}) ha richiesto l'autorizzazione dell'identità di sicurezza "{2}" sulla connessione al controller dell'host di test, ma è possibile autorizzare solo l'identità di una singola applicazione in modalità sandbox (in Windows, un identificatore di sicurezza nel formato 'S-1-15-2-...'). Agli utenti, ai gruppi e all'identificatore di sicurezza generico "{3}" non viene mai concesso l'accesso.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">このテスト アプリケーションに登録されているオプションを確認するには、'--help' を実行します。オプションが拡張機能に属している場合は、そのパッケージが参照され、拡張機能が登録されていることを確認してください。</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">このテスト アプリケーションに登録されているオプションを確認するには、'--help' を実行します。オプションが拡張機能に属している場合は、そのパッケージが参照され、拡張機能が登録されていることを確認してください。</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">代わりに、'--crashdump' または '--hangdump' を使用してください。MTP はクラッシュとハングの診断が分離されているため、VSTest の blame collector を 1 対 1 で置き換えるものはありません。</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">代わりに、'--crashdump' または '--hangdump' を使用してください。MTP はクラッシュとハングの診断が分離されているため、VSTest の blame collector を 1 対 1 で置き換えるものはありません。</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">同等のコンソールの詳細度を得るには、'--output {0}' を使用します。MTP コンソールの出力は異なる方法で構成されているため、これは完全な置き換えではありません。</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">同等のコンソールの詳細度を得るには、'--output {0}' を使用します。MTP コンソールの出力は異なる方法で構成されているため、これは完全な置き換えではありません。</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP では、'--report-trx'、'--report-html'、'--report-junit' などのレポーター固有のオプションが使用されます。レポーター拡張機能の MTP オプションについては、拡張機能のドキュメントを参照してください。</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP では、'--report-trx'、'--report-html'、'--report-junit' などのレポーター固有のオプションが使用されます。レポーター拡張機能の MTP オプションについては、拡張機能のドキュメントを参照してください。</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">MTP コード カバレッジには、'--coverage' を使用します。これは Coverlet の 'XPlat Code Coverage' コレクターを透過的に置き換えるものではありません。</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">MTP コード カバレッジには、'--coverage' を使用します。これは Coverlet の 'XPlat Code Coverage' コレクターを透過的に置き換えるものではありません。</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">拡張マニフェスト '{3}' で宣言されている、アセンブリ '{2}' の '{0}.{1}' 拡張フックは 'async void' として宣言されています。プラットフォームはフックを同期的に呼び出すため、最初の待機時に戻ります。その時点以降に登録する内容は、テスト アプリケーションのセットアップと競合し、失敗は失われます。フックを同期にします。</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">拡張マニフェスト '{3}' で宣言されている、アセンブリ '{2}' の '{0}.{1}' 拡張フックは 'async void' として宣言されています。プラットフォームはフックを同期的に呼び出すため、最初の待機時に戻ります。その時点以降に登録する内容は、テスト アプリケーションのセットアップと競合し、失敗は失われます。フックを同期にします。</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">拡張マニフェスト '{3}' で宣言されている、アセンブリ '{2}' の '{0}.{1}' 拡張フックは '{4}' を返しますが、'void' を返す必要があります。プラットフォームはフックを同期的に呼び出すため、戻り値は使用されません。特に、返されたタスクは待機されず、その登録と失敗は失われます。</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">拡張マニフェスト '{3}' で宣言されている、アセンブリ '{2}' の '{0}.{1}' 拡張フックは '{4}' を返しますが、'void' を返す必要があります。プラットフォームはフックを同期的に呼び出すため、戻り値は使用されません。特に、返されたタスクは待機されず、その登録と失敗は失われます。</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">拡張機能マニフェスト '{2}' で宣言されているアセンブリ '{1}' の型 '{0}' は、'ITestApplicationBuilder' と 'string[]' を受け取る '{3}' という名前の 'public static void' メソッドを公開していません。</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">拡張機能マニフェスト '{2}' で宣言されているアセンブリ '{1}' の型 '{0}' は、'ITestApplicationBuilder' と 'string[]' を受け取る '{3}' という名前の 'public static void' メソッドを公開していません。</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">拡張マニフェスト '{0}' は読み込む拡張機能を宣言していますが、現在のランタイムはアセンブリの動的読み込みをサポートしていません(例: ネイティブ AOT で公開した場合)。各拡張機能の '{1}' プロパティを 'false' に設定するか、マニフェストを削除するか、コマンド ラインから '{2}' を削除してください。</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">拡張マニフェスト '{0}' は読み込む拡張機能を宣言していますが、現在のランタイムはアセンブリの動的読み込みをサポートしていません(例: ネイティブ AOT で公開した場合)。各拡張機能の '{1}' プロパティを 'false' に設定するか、マニフェストを削除するか、コマンド ラインから '{2}' を削除してください。</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">テスト アプリケーションの横にある '*.testingplatformextensions.json' マニフェストで宣言されたテスト プラットフォーム拡張機能の読み込みを有効にします。既定では無効になっています。</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">テスト アプリケーションの横にある '*.testingplatformextensions.json' マニフェストで宣言されたテスト プラットフォーム拡張機能の読み込みを有効にします。既定では無効になっています。</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">指定された終了コードについて、非成功の終了値を報告しないでください。
+        <target state="needs-review-translation">指定された終了コードについて、非成功の終了値を報告しないでください。
 たとえば、'--ignore-exit-code 8;9' では終了コード 8 および 9 を無視して 0 を返します。
 終了コードの詳細については、https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes を参照してください。</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1050,15 +1050,15 @@ The default is TestResults in the directory that contains the test application.<
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">'timeout' オプションには、引数として明示的な単位サフィックスと、サポートされている範囲内 (最大約 49.7 日) の正の数値を持つ時間値を 1 つ指定する必要があります。使用可能なサフィックスは、'ms'/'mil(s)'/'millisecond(s)'、's'/'sec(s)'/'second(s)'、'm'/'min(s)'/'minute(s)'、'h'/'hour(s)'、'd'/'day(s)' です (例: '500ms'、'5400s'、'90m'、'1.5h'、'1d')。</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <target state="needs-review-translation">'timeout' オプションには、引数として明示的な単位サフィックスと、サポートされている範囲内 (最大約 49.7 日) の正の数値を持つ時間値を 1 つ指定する必要があります。使用可能なサフィックスは、'ms'/'mil(s)'/'millisecond(s)'、's'/'sec(s)'/'second(s)'、'm'/'min(s)'/'minute(s)'、'h'/'hour(s)'、'd'/'day(s)' です (例: '500ms'、'5400s'、'90m'、'1.5h'、'1d')。</target>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">グローバル テスト実行のタイムアウト。
+        <target state="needs-review-translation">グローバル テスト実行のタイムアウト。
 明示的な単位サフィックスを持つ時間値を 1 つ、引数として指定します。使用可能なサフィックスは、'ms'/'mil(s)'/'millisecond(s)'、's'/'sec(s)'/'second(s)'、'm'/'min(s)'/'minute(s)'、'h'/'hour(s)'、'd'/'day(s)' です (例: '500ms'、'5400s'、'90m'、'1.5h'、'1d')。</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Microsoft Testing Platform テレメトリの詳細: https://aka.ms/testingplatf
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">テスト ホスト ランチャー '{0}' (UID: {1}) は、テスト ホスト コントローラー接続でセキュリティ ID '{2}' の認可を要求しましたが、認可できるのは 1 つのサンドボックス化されたアプリケーションの ID (Windows では 'S-1-15-2-...' 形式のセキュリティ ID) のみです。ユーザー、グループ、包括的な '{3}' セキュリティ ID には、アクセスが付与されません。</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">テスト ホスト ランチャー '{0}' (UID: {1}) は、テスト ホスト コントローラー接続でセキュリティ ID '{2}' の認可を要求しましたが、認可できるのは 1 つのサンドボックス化されたアプリケーションの ID (Windows では 'S-1-15-2-...' 形式のセキュリティ ID) のみです。ユーザー、グループ、包括的な '{3}' セキュリティ ID には、アクセスが付与されません。</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">'--help'를 실행하여 이 테스트 애플리케이션에서 등록된 옵션을 확인합니다. 옵션이 확장에 속하는 경우 패키지가 참조되고 확장이 등록되어 있는지 확인합니다.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">'--help'를 실행하여 이 테스트 애플리케이션에서 등록된 옵션을 확인합니다. 옵션이 확장에 속하는 경우 패키지가 참조되고 확장이 등록되어 있는지 확인합니다.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">대신 '--crashdump' 및/또는 '--hangdump'를 사용하세요. MTP는 충돌 및 중단 진단을 분리하여 제공하므로, VSTest의 블레임 수집기를 일대일로 대체할 수는 없습니다.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">대신 '--crashdump' 및/또는 '--hangdump'를 사용하세요. MTP는 충돌 및 중단 진단을 분리하여 제공하므로, VSTest의 블레임 수집기를 일대일로 대체할 수는 없습니다.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">콘솔의 세부 정보 표시를 비교하려면 '--output {0}'를 사용합니다. 콘솔 출력MTP 다르게 구성되었으므로 정확한 대체가 아닙니다.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">콘솔의 세부 정보 표시를 비교하려면 '--output {0}'를 사용합니다. 콘솔 출력MTP 다르게 구성되었으므로 정확한 대체가 아닙니다.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP는 '--report-trx', '--report-html', '--report-junit'과 같은 리포터별 옵션을 사용합니다. 해당 MTP 옵션은 리포터 확장의 문서를 참조하세요.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP는 '--report-trx', '--report-html', '--report-junit'과 같은 리포터별 옵션을 사용합니다. 해당 MTP 옵션은 리포터 확장의 문서를 참조하세요.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">MTP 코드 검사에는 '--coverage'를 사용하세요. 이 옵션은 Coverlet의 'XPlat Code Coverage' 수집기를 그대로 대체하지는 않습니다.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">MTP 코드 검사에는 '--coverage'를 사용하세요. 이 옵션은 Coverlet의 'XPlat Code Coverage' 수집기를 그대로 대체하지는 않습니다.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">확장 매니페스트 '{3}'에 선언된 어셈블리 '{2}'의 '{0}.{1}' 확장 후크가 'async void'로 선언되어 있습니다. 플랫폼은 후크를 동기적으로 호출하므로 첫 번째 await에서 반환됩니다. 그 이후에 등록하는 항목은 테스트 애플리케이션 자체 설정과 경쟁하게 되며, 실패가 발생해도 기록되지 않습니다. 후크를 동기식으로 만드세요.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">확장 매니페스트 '{3}'에 선언된 어셈블리 '{2}'의 '{0}.{1}' 확장 후크가 'async void'로 선언되어 있습니다. 플랫폼은 후크를 동기적으로 호출하므로 첫 번째 await에서 반환됩니다. 그 이후에 등록하는 항목은 테스트 애플리케이션 자체 설정과 경쟁하게 되며, 실패가 발생해도 기록되지 않습니다. 후크를 동기식으로 만드세요.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">확장 매니페스트 '{3}'에 선언된 어셈블리 '{2}'의 '{0}.{1}' 확장 후크가 '{4}'을(를) 반환하지만, 반환 형식은 'void'여야 합니다. 플랫폼은 후크를 동기적으로 호출하므로 반환 값은 사용되지 않습니다. 특히 반환된 작업은 await되지 않으며, 그 안에서 등록한 내용과 실패는 모두 사라집니다.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">확장 매니페스트 '{3}'에 선언된 어셈블리 '{2}'의 '{0}.{1}' 확장 후크가 '{4}'을(를) 반환하지만, 반환 형식은 'void'여야 합니다. 플랫폼은 후크를 동기적으로 호출하므로 반환 값은 사용되지 않습니다. 특히 반환된 작업은 await되지 않으며, 그 안에서 등록한 내용과 실패는 모두 사라집니다.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">확장 매니페스트 '{2}'에 선언된 어셈블리 '{1}'의 형식 '{0}'에는 'ITestApplicationBuilder'와 'string[]'를 받는 '{3}'라는 'public static void' 메서드가 없습니다.</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">확장 매니페스트 '{2}'에 선언된 어셈블리 '{1}'의 형식 '{0}'에는 'ITestApplicationBuilder'와 'string[]'를 받는 '{3}'라는 'public static void' 메서드가 없습니다.</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">확장 매니페스트 '{0}'은(는) 로드할 확장을 선언하지만, 현재 런타임은 어셈블리를 동적으로 로드하는 기능을 지원하지 않습니다(예: 네이티브 AOT로 게시한 경우). 각 확장의 '{1}' 속성을 'false'로 설정하거나, 매니페스트를 제거하거나, 명령줄에서 '{2}'을(를) 제거하세요.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">확장 매니페스트 '{0}'은(는) 로드할 확장을 선언하지만, 현재 런타임은 어셈블리를 동적으로 로드하는 기능을 지원하지 않습니다(예: 네이티브 AOT로 게시한 경우). 각 확장의 '{1}' 속성을 'false'로 설정하거나, 매니페스트를 제거하거나, 명령줄에서 '{2}'을(를) 제거하세요.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">테스트 응용 프로그램 옆에서 찾은 '*.testingplatformextensions.json' 매니페스트에 선언된 테스트 플랫폼 확장 로드를 사용하도록 설정합니다. 기본적으로 사용하지 않도록 설정됩니다.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">테스트 응용 프로그램 옆에서 찾은 '*.testingplatformextensions.json' 매니페스트에 선언된 테스트 플랫폼 확장 로드를 사용하도록 설정합니다. 기본적으로 사용하지 않도록 설정됩니다.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">지정된 종료 코드에 대해 실패 종료 값을 보고하지 마세요.
+        <target state="needs-review-translation">지정된 종료 코드에 대해 실패 종료 값을 보고하지 마세요.
 예를 들어 '--ignore-exit-code 8;9'는 종료 코드 8과 9를 무시하고, 해당 경우에는 0을 반환합니다.
 종료 코드에 대한 자세한 내용은 https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes를 참조하세요.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1050,15 +1050,15 @@ The default is TestResults in the directory that contains the test application.<
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">'timeout' 옵션은 명시적 단위 접미사가 포함된 시간 값이어야 하며, 지원되는 범위(최대 약 49.7일) 내의 양수 값을 하나의 인수로 입력해야 합니다. 허용되는 접미사는 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', 'd'/'day(s)'입니다. (예: '500ms', '5400s', '90m', '1.5h', '1d')</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <target state="needs-review-translation">'timeout' 옵션은 명시적 단위 접미사가 포함된 시간 값이어야 하며, 지원되는 범위(최대 약 49.7일) 내의 양수 값을 하나의 인수로 입력해야 합니다. 허용되는 접미사는 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', 'd'/'day(s)'입니다. (예: '500ms', '5400s', '90m', '1.5h', '1d')</target>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">전역 테스트 실행 시간 제한입니다.
+        <target state="needs-review-translation">전역 테스트 실행 시간 제한입니다.
 명시적 단위 접미사가 포함된 시간 값을 하나의 인수로 입력해야 합니다. 허용되는 접미사는 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', 'd'/'day(s)'입니다. (예: '500ms', '5400s', '90m', '1.5h', '1d')</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Microsoft 테스트 플랫폼 원격 분석에 대해 자세히 알아보기: ht
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">테스트 호스트 시작 관리자 '{0}'(UID: {1})에서 테스트 호스트 컨트롤러 연결 시 보안 ID '{2}'에 권한을 부여해 달라고 요청했습니다. 하지만 단일 샌드박스가 적용된 애플리케이션의 ID만에만 권한을 부여할 수 있습니다(Windows에서는 'S-1-15-2-...' 형식의 보안 식별자). 사용자, 그룹 그리고 모두 캐치 '{3}' 보안 ID에는 절대 액세스 권한이 부여되지 않습니다.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">테스트 호스트 시작 관리자 '{0}'(UID: {1})에서 테스트 호스트 컨트롤러 연결 시 보안 ID '{2}'에 권한을 부여해 달라고 요청했습니다. 하지만 단일 샌드박스가 적용된 애플리케이션의 ID만에만 권한을 부여할 수 있습니다(Windows에서는 'S-1-15-2-...' 형식의 보안 식별자). 사용자, 그룹 그리고 모두 캐치 '{3}' 보안 ID에는 절대 액세스 권한이 부여되지 않습니다.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Uruchom „--help”, aby zobaczyć opcje zarejestrowane przez tę aplikację testową. Jeśli opcja należy do rozszerzenia, upewnij się, że jego pakiet jest uwzględniony jako odwołanie i że rozszerzenie jest zarejestrowane.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Uruchom „--help”, aby zobaczyć opcje zarejestrowane przez tę aplikację testową. Jeśli opcja należy do rozszerzenia, upewnij się, że jego pakiet jest uwzględniony jako odwołanie i że rozszerzenie jest zarejestrowane.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">Zamiast tego użyj '--crashdump' i/lub '--hangdump'. MTP rozdziela diagnostykę awarii i zawieszeń, więc nie ma tu zamiennika jeden do jednego dla kolektora blame w VSTest.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">Zamiast tego użyj '--crashdump' i/lub '--hangdump'. MTP rozdziela diagnostykę awarii i zawieszeń, więc nie ma tu zamiennika jeden do jednego dla kolektora blame w VSTest.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Aby uzyskać porównywalną szczegółowość danych wyjściowych konsoli, użyj '--output {0}'. Dane wyjściowe konsoli MTP są skonfigurowane inaczej, więc nie jest to dokładny zamiennik.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Aby uzyskać porównywalną szczegółowość danych wyjściowych konsoli, użyj '--output {0}'. Dane wyjściowe konsoli MTP są skonfigurowane inaczej, więc nie jest to dokładny zamiennik.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP używa opcji specyficznych dla raportera, takich jak '--report-trx', '--report-html', i '--report-junit'. Informacje o opcjach MTP znajdziesz w dokumentacji rozszerzenia raportera.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP używa opcji specyficznych dla raportera, takich jak '--report-trx', '--report-html', i '--report-junit'. Informacje o opcjach MTP znajdziesz w dokumentacji rozszerzenia raportera.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">Aby uzyskać pokrycie kodu w MTP, użyj '--coverage'. Nie jest to bezpośredni zamiennik kolektora 'XPlat Code Coverage' w Coverlet.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">Aby uzyskać pokrycie kodu w MTP, użyj '--coverage'. Nie jest to bezpośredni zamiennik kolektora 'XPlat Code Coverage' w Coverlet.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">Element zaczepienia rozszerzenia „{0}.{1}” z zestawu „{2}” zadeklarowany w manifeście rozszerzenia „{3}” jest zadeklarowany jako 'async void'. Platforma wywołuje punkt zaczepienia synchronicznie, więc wróci po pierwszym oczekiwaniu: wszystko, co zarejestruje po tym punkcie, spowoduje wyścig z konfiguracją aplikacji testowej, a wszelkie awarie zostaną utracone. Ustaw element wpięcia jako synchroniczny.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">Element zaczepienia rozszerzenia „{0}.{1}” z zestawu „{2}” zadeklarowany w manifeście rozszerzenia „{3}” jest zadeklarowany jako 'async void'. Platforma wywołuje punkt zaczepienia synchronicznie, więc wróci po pierwszym oczekiwaniu: wszystko, co zarejestruje po tym punkcie, spowoduje wyścig z konfiguracją aplikacji testowej, a wszelkie awarie zostaną utracone. Ustaw element wpięcia jako synchroniczny.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">Element zaczepienia rozszerzenia "{0}.{1}” z zestawu „{2}” zadeklarowany w manifeście rozszerzenia „{3}” zwraca wartość „{4}”, ale musi zwracać wartość 'void'. Platforma wywołuje element zaczepienia synchronicznie, więc zwracana wartość nigdy nie jest obserwowana; zwrócone zadanie w szczególności nigdy nie będzie oczekiwane, a jego rejestracje i błędy zostaną utracone.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">Element zaczepienia rozszerzenia "{0}.{1}” z zestawu „{2}” zadeklarowany w manifeście rozszerzenia „{3}” zwraca wartość „{4}”, ale musi zwracać wartość 'void'. Platforma wywołuje element zaczepienia synchronicznie, więc zwracana wartość nigdy nie jest obserwowana; zwrócone zadanie w szczególności nigdy nie będzie oczekiwane, a jego rejestracje i błędy zostaną utracone.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">Typ „{0}” w zestawie „{1}” zadeklarowany w manifeście rozszerzenia „{2}” nie ujawnia metody 'public static void' o nazwie „{3}” przyjmującej element 'ITestApplicationBuilder' i 'string[]'.</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">Typ „{0}” w zestawie „{1}” zadeklarowany w manifeście rozszerzenia „{2}” nie ujawnia metody 'public static void' o nazwie „{3}” przyjmującej element 'ITestApplicationBuilder' i 'string[]'.</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">Manifest rozszerzenia „{0}” deklaruje rozszerzenia do załadowania, ale bieżące środowisko uruchomieniowe nie obsługuje dynamicznego ładowania zestawów (na przykład w przypadku publikowania z natywnym kodem AOT). Ustaw właściwość „{1}” każdego rozszerzenia na wartość 'false', usuń manifest lub usuń element „{2}” z wiersza polecenia.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">Manifest rozszerzenia „{0}” deklaruje rozszerzenia do załadowania, ale bieżące środowisko uruchomieniowe nie obsługuje dynamicznego ładowania zestawów (na przykład w przypadku publikowania z natywnym kodem AOT). Ustaw właściwość „{1}” każdego rozszerzenia na wartość 'false', usuń manifest lub usuń element „{2}” z wiersza polecenia.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Opcjonalnie akceptuje „text” (domyślne dane wyjściowe czytelne dla człowi
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Włącz ładowanie rozszerzeń platformy testowej zadeklarowanych przez manifesty '*.testingplatformextensions.json' znajdujące się obok aplikacji testowej. Domyślnie wyłączone.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Włącz ładowanie rozszerzeń platformy testowej zadeklarowanych przez manifesty '*.testingplatformextensions.json' znajdujące się obok aplikacji testowej. Domyślnie wyłączone.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Opcjonalnie akceptuje „text” (domyślne dane wyjściowe czytelne dla człowi
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">Nie zgłaszaj wartości niepomyślnego zakończenia dla określonych kodów zakończenia.
+        <target state="needs-review-translation">Nie zgłaszaj wartości niepomyślnego zakończenia dla określonych kodów zakończenia.
 Na przykład '--ignore-exit-code 8;9' ignoruje kody zakończenia 8 i 9 i zwraca wartość 0 w tych przypadkach.
 Aby uzyskać więcej informacji na temat kodów zakończenia, zobacz stronę https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1051,14 +1051,14 @@ Wartość domyślna to TestResults w katalogu zawierającym aplikację testową.
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Więcej informacji o telemetrii platformy testowej firmy Microsoft: https://aka.
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">Moduł uruchamiający hosta testowego „{0}”" (UID: {1}) poprosił o autoryzację tożsamości zabezpieczeń „{2}” w testowym połączeniu kontrolera hosta, ale tylko tożsamość pojedynczej aplikacji w trybie środowiska testowego (w systemie Windows identyfikator zabezpieczeń w postaci „S-1-15-2-...”) może być autoryzowana. Użytkownikom, grupom i identyfikatorowi zabezpieczeń catch-all „{3}” nigdy nie udzielono dostępu.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">Moduł uruchamiający hosta testowego „{0}”" (UID: {1}) poprosił o autoryzację tożsamości zabezpieczeń „{2}” w testowym połączeniu kontrolera hosta, ale tylko tożsamość pojedynczej aplikacji w trybie środowiska testowego (w systemie Windows identyfikator zabezpieczeń w postaci „S-1-15-2-...”) może być autoryzowana. Użytkownikom, grupom i identyfikatorowi zabezpieczeń catch-all „{3}” nigdy nie udzielono dostępu.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Execute ''--help'' para ver as opções registradas por este aplicativo de teste. Se a opção pertencer a uma extensão, certifique-se de que o pacote é referenciado e se a extensão está registrada.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Execute ''--help'' para ver as opções registradas por este aplicativo de teste. Se a opção pertencer a uma extensão, certifique-se de que o pacote é referenciado e se a extensão está registrada.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">Use '--crashdump' e/ou '--hangdump' em vez disso. O MTP separa os diagnósticos de falha e de travamento, então não existe um substituto direto para o coletor de blame do VSTest.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">Use '--crashdump' e/ou '--hangdump' em vez disso. O MTP separa os diagnósticos de falha e de travamento, então não existe um substituto direto para o coletor de blame do VSTest.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Para obter detalhes comparáveis do console, use '--output {0}'. MTP saída do console está configurada de forma diferente, portanto, essa não é uma substituição exata.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Para obter detalhes comparáveis do console, use '--output {0}'. MTP saída do console está configurada de forma diferente, portanto, essa não é uma substituição exata.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">O MTP usa opções específicas do relator, como '--report-trx', '--report-html' e '--report-junit'. Consulte a documentação da extensão do relator para obter sua opção de MTP.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">O MTP usa opções específicas do relator, como '--report-trx', '--report-html' e '--report-junit'. Consulte a documentação da extensão do relator para obter sua opção de MTP.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">Para cobertura de código no MTP, use '--coverage'. Isso não é um substituto direto para o coletor 'XPlat Code Coverage' do Coverlet.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">Para cobertura de código no MTP, use '--coverage'. Isso não é um substituto direto para o coletor 'XPlat Code Coverage' do Coverlet.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">O gancho de extensão ''{0}.{1}'' do assembly ''{2}'', declarado no manifesto de extensão ''{3}'', está marcado como ''async void''. A plataforma invoca o gancho de forma síncrona, portanto, ele retornaria no primeiro await: tudo o que ele registrar depois desse ponto concorreria com a configuração do próprio aplicativo de teste, e qualquer falha seria perdida. Torne o gancho síncrono.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">O gancho de extensão ''{0}.{1}'' do assembly ''{2}'', declarado no manifesto de extensão ''{3}'', está marcado como ''async void''. A plataforma invoca o gancho de forma síncrona, portanto, ele retornaria no primeiro await: tudo o que ele registrar depois desse ponto concorreria com a configuração do próprio aplicativo de teste, e qualquer falha seria perdida. Torne o gancho síncrono.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">O gancho de extensão ''{0}.{1}'' do assembly ''{2}'', declarado no manifesto de extensão ''{3}'', retorna ''{4}'', mas deve retornar ''void''. A plataforma invoca o gancho de forma síncrona, portanto, um valor de retorno nunca é observado; em particular, uma tarefa retornada nunca seria aguardada, e suas inscrições e falhas seriam perdidas.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">O gancho de extensão ''{0}.{1}'' do assembly ''{2}'', declarado no manifesto de extensão ''{3}'', retorna ''{4}'', mas deve retornar ''void''. A plataforma invoca o gancho de forma síncrona, portanto, um valor de retorno nunca é observado; em particular, uma tarefa retornada nunca seria aguardada, e suas inscrições e falhas seriam perdidas.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">O tipo ''{0}'' no assembly ''{1}'', declarado no manifesto de extensão ''{2}'', não expõe um método ''public static void'' chamado ''{3}'', que receba um ''ITestApplicationBuilder'' e um ''string[]''.</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">O tipo ''{0}'' no assembly ''{1}'', declarado no manifesto de extensão ''{2}'', não expõe um método ''public static void'' chamado ''{3}'', que receba um ''ITestApplicationBuilder'' e um ''string[]''.</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">O manifesto de extensão ''{0}'' declara as extensões para carregar, mas o runtime atual não dá suporte ao carregamento dinâmico de assemblies (por exemplo, quando publicado com AOT nativo). Defina a propriedade ''{1}'' de cada extensão como ''false'', remova o manifesto ou remova ''{2}'' da linha de comando.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">O manifesto de extensão ''{0}'' declara as extensões para carregar, mas o runtime atual não dá suporte ao carregamento dinâmico de assemblies (por exemplo, quando publicado com AOT nativo). Defina a propriedade ''{1}'' de cada extensão como ''false'', remova o manifesto ou remova ''{2}'' da linha de comando.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Opcionalmente, aceita 'text' (a saída legível por humanos padrão) ou 'json' p
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Ative o carregamento de extensões da plataforma de teste declaradas por manifestos ''*.testingplatformextensions.json'' encontrados ao lado do aplicativo de teste. Desabilitado por padrão.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Ative o carregamento de extensões da plataforma de teste declaradas por manifestos ''*.testingplatformextensions.json'' encontrados ao lado do aplicativo de teste. Desabilitado por padrão.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Opcionalmente, aceita 'text' (a saída legível por humanos padrão) ou 'json' p
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">Não relate um valor de saída não bem-sucedido para os códigos de saída especificados.
+        <target state="needs-review-translation">Não relate um valor de saída não bem-sucedido para os códigos de saída especificados.
 Por exemplo, ''--ignore-exit-code 8;9'' ignora os códigos de saída 8 e 9 e retorna 0 nesses casos.
 Para obter mais informações sobre os códigos de saída, veja https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1050,15 +1050,15 @@ O padrão é TestResults no diretório que contém o aplicativo de teste.</targe
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">A opção 'timeout' deve ter um argumento como valor temporal, com um sufixo de unidade explícito, e um valor numérico positivo dentro do intervalo compatível (até ~49,7 dias). Os sufixos aceitos são 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' e 'd'/'day(s)'. Por exemplo: '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <target state="needs-review-translation">A opção 'timeout' deve ter um argumento como valor temporal, com um sufixo de unidade explícito, e um valor numérico positivo dentro do intervalo compatível (até ~49,7 dias). Os sufixos aceitos são 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' e 'd'/'day(s)'. Por exemplo: '500ms', '5400s', '90m', '1.5h', '1d'.</target>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">Um tempo limite global de execução de teste.
+        <target state="needs-review-translation">Um tempo limite global de execução de teste.
 Recebe um argumento como valor temporal, com um sufixo de unidade explícito. Os sufixos aceitos são 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' e 'd'/'day(s)'. Por exemplo: '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Leia mais sobre a telemetria da Plataforma de Testes da Microsoft: https://aka.m
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">O inicializador de host de teste "{0}" (UID: {1}) solicitou autorizar a identidade de segurança "{2}" na conexão do controlador de host de teste, mas apenas a identidade de um único aplicativo em área restrita (no Windows, um identificador de segurança do formato 'S-1-15-2-...') pode ser autorizado. Usuários, grupos e o identificador de segurança catch-all "{3}" nunca recebem acesso.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">O inicializador de host de teste "{0}" (UID: {1}) solicitou autorizar a identidade de segurança "{2}" na conexão do controlador de host de teste, mas apenas a identidade de um único aplicativo em área restrita (no Windows, um identificador de segurança do formato 'S-1-15-2-...') pode ser autorizado. Usuários, grupos e o identificador de segurança catch-all "{3}" nunca recebem acesso.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Запустите "--help", чтобы просмотреть параметры, зарегистрированные этим тестовым приложением. Если параметр относится к расширению, проверьте, указан ли его пакет и зарегистрировано ли расширение.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Запустите "--help", чтобы просмотреть параметры, зарегистрированные этим тестовым приложением. Если параметр относится к расширению, проверьте, указан ли его пакет и зарегистрировано ли расширение.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">Взамен используйте '--crashdump' и (или) '--hangdump'. MTP разделяет диагностику сбоев и зависаний, поэтому для сборщика blame в VSTest нет прямой замены.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">Взамен используйте '--crashdump' и (или) '--hangdump'. MTP разделяет диагностику сбоев и зависаний, поэтому для сборщика blame в VSTest нет прямой замены.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Для сопоставимого уровня детализации вывода в консоли используйте '--output {0}'. Вывод MTP в консоль настраивается по-другому, поэтому это не точная замена.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Для сопоставимого уровня детализации вывода в консоли используйте '--output {0}'. Вывод MTP в консоль настраивается по-другому, поэтому это не точная замена.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP использует параметры для конкретного модуля формирования отчетов, такие как '--report-trx', '--report-html' и '--report-junit'. Сведения о параметре MTP см. в документации по расширению модуля формирования отчетов.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP использует параметры для конкретного модуля формирования отчетов, такие как '--report-trx', '--report-html' и '--report-junit'. Сведения о параметре MTP см. в документации по расширению модуля формирования отчетов.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">Для объема протестированного кода в MTP используйте '--coverage'. Это не прозрачная замена сборщика 'XPlat Code Coverage' в Coverlet.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">Для объема протестированного кода в MTP используйте '--coverage'. Это не прозрачная замена сборщика 'XPlat Code Coverage' в Coverlet.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">Обработчик расширения "{0}.{1}" из сборки "{2}", объявленный в манифесте расширения "{3}", объявлен как "async void". Платформа вызывает обработчик синхронно, поэтому он вернет управление на первом операторе "await": все, что он регистрирует после этой точки, будет конкурировать с собственной настройкой тестового приложения, а любой сбой будет потерян. Сделайте обработчик синхронным.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">Обработчик расширения "{0}.{1}" из сборки "{2}", объявленный в манифесте расширения "{3}", объявлен как "async void". Платформа вызывает обработчик синхронно, поэтому он вернет управление на первом операторе "await": все, что он регистрирует после этой точки, будет конкурировать с собственной настройкой тестового приложения, а любой сбой будет потерян. Сделайте обработчик синхронным.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">Обработчик расширения "{0}.{1}" из сборки "{2}", объявленный в манифесте расширения "{3}", возвращает "{4}", но должен возвращать "void". Платформа вызывает обработчик синхронно, поэтому возвращаемое значение никогда не наблюдается; в частности, возвращаемая задача никогда не будет ожидаться, а ее регистрации и сбои будут потеряны.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">Обработчик расширения "{0}.{1}" из сборки "{2}", объявленный в манифесте расширения "{3}", возвращает "{4}", но должен возвращать "void". Платформа вызывает обработчик синхронно, поэтому возвращаемое значение никогда не наблюдается; в частности, возвращаемая задача никогда не будет ожидаться, а ее регистрации и сбои будут потеряны.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">Тип "{0}" в сборке "{1}", объявленный в манифесте расширения "{2}", не предоставляет метод "public static void" с именем "{3}", принимающий "ITestApplicationBuilder" и "string[]".</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">Тип "{0}" в сборке "{1}", объявленный в манифесте расширения "{2}", не предоставляет метод "public static void" с именем "{3}", принимающий "ITestApplicationBuilder" и "string[]".</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">Манифест расширения "{0}" объявляет расширения для загрузки, но текущая среда выполнения не поддерживает динамическую загрузку сборок (например, при публикации с использованием собственного AOT). Установите свойство "{1}" каждого расширения в значение "false", удалите манифест или уберите "{2}" из командной строки.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">Манифест расширения "{0}" объявляет расширения для загрузки, но текущая среда выполнения не поддерживает динамическую загрузку сборок (например, при публикации с использованием собственного AOT). Установите свойство "{1}" каждого расширения в значение "false", удалите манифест или уберите "{2}" из командной строки.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Включить загрузку расширений тестовой платформы, объявленных в манифестах "*.testingplatformextensions.json", найденных рядом с тестовым приложением. По умолчанию отключено.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Включить загрузку расширений тестовой платформы, объявленных в манифестах "*.testingplatformextensions.json", найденных рядом с тестовым приложением. По умолчанию отключено.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">Не сообщать о неуспешном значении завершения для указанных кодов завершения.
+        <target state="needs-review-translation">Не сообщать о неуспешном значении завершения для указанных кодов завершения.
 Например, "'--ignore-exit-code 8;9" игнорирует коды завершения 8 и 9 и в этих случаях возвращает 0.
 Дополнительные сведения о кодах завершения см. на странице https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1051,14 +1051,14 @@ The default is TestResults in the directory that contains the test application.<
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">Средство запуска тестового узла "{0}" (UID: {1}) запросило авторизацию удостоверения безопасности "{2}" для подключения к контроллеру тестового узла, но можно авторизовать только удостоверение одного приложения в песочнице (в Windows — идентификатор безопасности вида 'S-1-15-2-...'). Пользователям, группам и универсальному идентификатору безопасности "{3}" доступ никогда не предоставляется.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">Средство запуска тестового узла "{0}" (UID: {1}) запросило авторизацию удостоверения безопасности "{2}" для подключения к контроллеру тестового узла, но можно авторизовать только удостоверение одного приложения в песочнице (в Windows — идентификатор безопасности вида 'S-1-15-2-...'). Пользователям, группам и универсальному идентификатору безопасности "{3}" доступ никогда не предоставляется.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">Bu test uygulaması tarafından kaydedilen seçenekleri görmek için '--help' komutunu çalıştırın. Seçenek bir uzantıya aitse, paketine başvurulduğundan ve uzantının kaydedildiğinden emin olun.</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">Bu test uygulaması tarafından kaydedilen seçenekleri görmek için '--help' komutunu çalıştırın. Seçenek bir uzantıya aitse, paketine başvurulduğundan ve uzantının kaydedildiğinden emin olun.</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">Bunun yerine '--crashdump' ve/veya '--hangdump' seçeneklerini kullanın. MTP, kilitlenme ve takılma tanılamasını ayırır, bu nedenle VSTest blame toplayıcısının bire bir karşılığı yoktur.</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">Bunun yerine '--crashdump' ve/veya '--hangdump' seçeneklerini kullanın. MTP, kilitlenme ve takılma tanılamasını ayırır, bu nedenle VSTest blame toplayıcısının bire bir karşılığı yoktur.</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">Karşılaştırılabilir konsol ayrıntı düzeyi için '--output {0}' seçeneğini kullanın. MTP konsol çıkışı farklı yapılandırıldığından bu tam bir değiştirme değildir.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">Karşılaştırılabilir konsol ayrıntı düzeyi için '--output {0}' seçeneğini kullanın. MTP konsol çıkışı farklı yapılandırıldığından bu tam bir değiştirme değildir.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP, '--report-trx', '--report-html' ve '--report-junit' gibi raporlayıcıya özgü seçenekleri kullanır. MTP seçeneği için raporlayıcı uzantısının belgelerine bakın.</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP, '--report-trx', '--report-html' ve '--report-junit' gibi raporlayıcıya özgü seçenekleri kullanır. MTP seçeneği için raporlayıcı uzantısının belgelerine bakın.</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">MTP kod kapsamı için '--coverage' seçeneğini kullanın. Bu, Coverlet'in 'XPlat Code Coverage' toplayıcısı için saydam bir değiştirme değildir.</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">MTP kod kapsamı için '--coverage' seçeneğini kullanın. Bu, Coverlet'in 'XPlat Code Coverage' toplayıcısı için saydam bir değiştirme değildir.</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">“{3}” uzantı bildiriminde bildirilen “{2}” derlemesindeki “{0}.{1}” uzantı kancası “async void” olarak bildirilmiş. Platform kancayı senkron olarak çağırır, bu nedenle ilk await ifadesinde geri döner; bu noktadan sonra kaydettiği her şey test uygulamasının kendi kurulumuyla yarışır ve herhangi bir hata kaybolur. Kancayı senkron yapın.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">“{3}” uzantı bildiriminde bildirilen “{2}” derlemesindeki “{0}.{1}” uzantı kancası “async void” olarak bildirilmiş. Platform kancayı senkron olarak çağırır, bu nedenle ilk await ifadesinde geri döner; bu noktadan sonra kaydettiği her şey test uygulamasının kendi kurulumuyla yarışır ve herhangi bir hata kaybolur. Kancayı senkron yapın.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">“{3}” uzantı bildiriminde bildirilen “{2}” derlemesindeki “{0}.{1}” uzantı kancası “{4}” döndürüyor, ancak “void” döndürmelidir. Platform kancayı eşzamanlı olarak çağırır, bu nedenle hiçbir geri gönderme değeri gözlemlenmez; özellikle döndürülen bir görev hiçbir zaman await edilmez ve kayıtları ile hataları kaybolur.</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">“{3}” uzantı bildiriminde bildirilen “{2}” derlemesindeki “{0}.{1}” uzantı kancası “{4}” döndürüyor, ancak “void” döndürmelidir. Platform kancayı eşzamanlı olarak çağırır, bu nedenle hiçbir geri gönderme değeri gözlemlenmez; özellikle döndürülen bir görev hiçbir zaman await edilmez ve kayıtları ile hataları kaybolur.</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">“{2}” uzantı bildiriminde bildirilen “{1}” derlemesindeki “{0}” türü, ITestApplicationBuilder ve string[] alan “{3}” adlı public static void yöntemini kullanıma sunmuyor.</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">“{2}” uzantı bildiriminde bildirilen “{1}” derlemesindeki “{0}” türü, ITestApplicationBuilder ve string[] alan “{3}” adlı public static void yöntemini kullanıma sunmuyor.</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">Uzantı bildirimi '{0}', yüklemek için uzantılar bildiriyor, ancak geçerli clr çalışma zamanı derlemeleri dinamik olarak yüklemeyi desteklemiyor (örneğin, native AOT ile yayımlandığında). Her uzantının '{1}' özelliğini 'false' olarak ayarlayın, bildirimi kaldırın veya komut satırından '{2}' seçeneğini kaldırın.</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">Uzantı bildirimi '{0}', yüklemek için uzantılar bildiriyor, ancak geçerli clr çalışma zamanı derlemeleri dinamik olarak yüklemeyi desteklemiyor (örneğin, native AOT ile yayımlandığında). Her uzantının '{1}' özelliğini 'false' olarak ayarlayın, bildirimi kaldırın veya komut satırından '{2}' seçeneğini kaldırın.</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">Test uygulamasının yanında bulunan '*.testingplatformextensions.json' bildirimleri tarafından bildirilen test platformu uzantılarının yüklenmesini etkinleştirin. Varsayılan olarak devre dışıdır.</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">Test uygulamasının yanında bulunan '*.testingplatformextensions.json' bildirimleri tarafından bildirilen test platformu uzantılarının yüklenmesini etkinleştirin. Varsayılan olarak devre dışıdır.</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">Belirtilen çıkış kodları için başarı dışı bir çıkış değeri bildirmeyin.
+        <target state="needs-review-translation">Belirtilen çıkış kodları için başarı dışı bir çıkış değeri bildirmeyin.
 Örneğin, '--ignore-exit-code 8;9' 8 ve 9 çıkış kodlarını yoksayar ve bu durumlarda 0 döndürür.
 Çıkış kodları hakkında daha fazla bilgi için https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes adresine bakın.</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1050,15 +1050,15 @@ Varsayılan değer, test uygulamasını içeren dizindeki TestResults'dır.</tar
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">'timeout' seçeneğinin, açık birim soneki ve desteklenen aralıkta (en fazla yaklaşık 49,7 gün) olan pozitif bir sayısal değer içeren bir zaman değeri olarak tek bir bağımsız değişkeni olmalıdır. Kabul edilen sonekler: 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', ör. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <target state="needs-review-translation">'timeout' seçeneğinin, açık birim soneki ve desteklenen aralıkta (en fazla yaklaşık 49,7 gün) olan pozitif bir sayısal değer içeren bir zaman değeri olarak tek bir bağımsız değişkeni olmalıdır. Kabul edilen sonekler: 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', ör. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">Genel bir test yürütme zaman aşımı.
+        <target state="needs-review-translation">Genel bir test yürütme zaman aşımı.
 Açık bir birim soneki bulunan bir zaman değeri olarak bir bağımsız değişken alır. Kabul edilen sonekler: 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', ör. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Microsoft Test Platformu telemetrisi hakkında daha fazla bilgi edinin: https://
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">Test konağı başlatıcısı '{0}' (UID: {1}) '{2}' güvenlik kimliğinin test konağı denetleyici bağlantısında yetkilendirilmesini istedi, ancak yalnızca korumalı tek bir uygulama (Windows'da, 'S-1-15-2-...' biçiminde bir güvenlik tanımlayıcısı) yetkilendirilebilir. Kullanıcılara, gruplara ve kapsayıcı '{3}' güvenlik tanımlayıcısına hiçbir zaman erişim izni verilmez.</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">Test konağı başlatıcısı '{0}' (UID: {1}) '{2}' güvenlik kimliğinin test konağı denetleyici bağlantısında yetkilendirilmesini istedi, ancak yalnızca korumalı tek bir uygulama (Windows'da, 'S-1-15-2-...' biçiminde bir güvenlik tanımlayıcısı) yetkilendirilebilir. Kullanıcılara, gruplara ve kapsayıcı '{3}' güvenlik tanımlayıcısına hiçbir zaman erişim izni verilmez.</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">运行 '--help' 以查看此测试应用程序注册的选项。如果该选项属于扩展，请确保引用其包并注册扩展。</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">运行 '--help' 以查看此测试应用程序注册的选项。如果该选项属于扩展，请确保引用其包并注册扩展。</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">请改用 '--crashdump' 和/或 '--hangdump'。MTP 分离了崩溃和挂起诊断，因此 VSTest 故障收集器不存在一对一替代项。</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">请改用 '--crashdump' 和/或 '--hangdump'。MTP 分离了崩溃和挂起诊断，因此 VSTest 故障收集器不存在一对一替代项。</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">要实现同等的控制台详细程度，请使用 '--output {0}'。MTP 控制台输出的配置方式不同，因此这不是完全替换。</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">要实现同等的控制台详细程度，请使用 '--output {0}'。MTP 控制台输出的配置方式不同，因此这不是完全替换。</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP 使用特定于报告器的选项，例如 '--report-trx'、'--report-html' 和 '--report-junit'。有关其 MTP 选项，请查阅报告器扩展的文档。</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP 使用特定于报告器的选项，例如 '--report-trx'、'--report-html' 和 '--report-junit'。有关其 MTP 选项，请查阅报告器扩展的文档。</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">对于 MTP 代码覆盖率，请使用 '--coverage'。这不是 Coverlet 的 'XPlat Code Coverage' 收集器的透明替代。</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">对于 MTP 代码覆盖率，请使用 '--coverage'。这不是 Coverlet 的 'XPlat Code Coverage' 收集器的透明替代。</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">来自扩展清单“{3}”中声明的程序集“{2}”的“{0}.{1}”扩展挂钩声明为 'async void'。平台会同步调用挂钩，因此它将在遇到第一个等待时返回: 它在此时间点之后注册的任何内容都将与测试应用程序自己的设置发生争用，并且任何失败都将丢失。将挂钩设置为同步。</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">来自扩展清单“{3}”中声明的程序集“{2}”的“{0}.{1}”扩展挂钩声明为 'async void'。平台会同步调用挂钩，因此它将在遇到第一个等待时返回: 它在此时间点之后注册的任何内容都将与测试应用程序自己的设置发生争用，并且任何失败都将丢失。将挂钩设置为同步。</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">扩展清单“{3}”中声明的程序集“{2}”中的“{0}.{1}”扩展挂钩返回“{4}”，但必须返回 'void'。平台会同步调用挂钩，因此永远不会观察到返回值；特别是，永远不会等待返回的任务，并且其注册和失败将会丢失。</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">扩展清单“{3}”中声明的程序集“{2}”中的“{0}.{1}”扩展挂钩返回“{4}”，但必须返回 'void'。平台会同步调用挂钩，因此永远不会观察到返回值；特别是，永远不会等待返回的任务，并且其注册和失败将会丢失。</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">扩展清单“{2}”中声明的程序集“{1}”中的类型“{0}”不公开采用 'ITestApplicationBuilder' 和 'string[]' 且名为“{3}”的 'public static void' 方法。</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">扩展清单“{2}”中声明的程序集“{1}”中的类型“{0}”不公开采用 'ITestApplicationBuilder' 和 'string[]' 且名为“{3}”的 'public static void' 方法。</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">扩展清单“{0}”声明了要加载的扩展，但当前运行时不支持动态加载程序集(例如，使用本机 AOT 发布时)。将每个扩展的“{1}”属性设置为 'false'、移除清单，或从命令行中移除“{2}”。</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">扩展清单“{0}”声明了要加载的扩展，但当前运行时不支持动态加载程序集(例如，使用本机 AOT 发布时)。将每个扩展的“{1}”属性设置为 'false'、移除清单，或从命令行中移除“{2}”。</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">启用加载由测试应用程序旁边的 '*.testingplatformextensions.json' 清单声明的测试平台扩展。默认情况下禁用。</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">启用加载由测试应用程序旁边的 '*.testingplatformextensions.json' 清单声明的测试平台扩展。默认情况下禁用。</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">不报告指定退出代码的非成功退出值。
+        <target state="needs-review-translation">不报告指定退出代码的非成功退出值。
 例如，'--ignore-exit-code 8;9' 将在这些情况下忽略退出代码 8 和 9 并返回 0。
 有关退出代码的详细信息，请参阅 https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes。</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1051,14 +1051,14 @@ The default is TestResults in the directory that contains the test application.<
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Microsoft 测试平台会收集使用数据，帮助我们改善体验。该数�
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">测试主机启动器 "{0}"(UID: {1})请求在测试主机控制器连接上授权安全标识符 "{2}"，但只能授权单个沙盒应用的标识符(在 Windows 上，格式为 "S-1-15-2-..." 的安全标识符)。从不向用户、组以及通用 "{3}" 安全标识符授予访问权限。</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">测试主机启动器 "{0}"(UID: {1})请求在测试主机控制器连接上授权安全标识符 "{2}"，但只能授权单个沙盒应用的标识符(在 Windows 上，格式为 "S-1-15-2-..." 的安全标识符)。从不向用户、组以及通用 "{3}" 安全标识符授予访问权限。</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -284,13 +284,13 @@
       </trans-unit>
       <trans-unit id="CommandLineUnknownOptionsHint">
         <source>Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</source>
-        <target state="translated">執行 '--help' 以查看此測試應用程式註冊的選項。如果該選項屬於延伸模組，請確認已參考其套件，且已註冊該延伸模組。</target>
-        <note>{Locked="'--help'"}</note>
+        <target state="needs-review-translation">執行 '--help' 以查看此測試應用程式註冊的選項。如果該選項屬於延伸模組，請確認已參考其套件，且已註冊該延伸模組。</target>
+        <note>{Locked="--help"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestBlameReplacement">
         <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
-        <target state="translated">請改用 '--crashdump' 和/或 '--hangdump'。MTP 將當機與停止回應診斷分開，因此沒有能一對一取代 VSTest blame 收集器的功能。</target>
-        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+        <target state="needs-review-translation">請改用 '--crashdump' 和/或 '--hangdump'。MTP 將當機與停止回應診斷分開，因此沒有能一對一取代 VSTest blame 收集器的功能。</target>
+        <note>{Locked="--crashdump"}{Locked="--hangdump"}{Locked="MTP"}{Locked="VSTest"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestCollectorGuidance">
         <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
@@ -299,13 +299,13 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
-        <target state="translated">如需相近的主控台詳細程度，請使用 '--output {0}'。MTP 主控台輸出的設定不同，因此這不是完全的取代項目。</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
+        <target state="needs-review-translation">如需相近的主控台詳細程度，請使用 '--output {0}'。MTP 主控台輸出的設定不同，因此這不是完全的取代項目。</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="--output {0}"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
-        <target state="translated">MTP 使用報表器特定選項，例如 '--report-trx'、'--report-html' 和 '--report-junit'。請參閱報表器延伸模組的文件，了解其 MTP 選項。</target>
-        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+        <target state="needs-review-translation">MTP 使用報表器特定選項，例如 '--report-trx'、'--report-html' 和 '--report-junit'。請參閱報表器延伸模組的文件，了解其 MTP 選項。</target>
+        <note>{Locked="MTP"}{Locked="--report-trx"}{Locked="--report-html"}{Locked="--report-junit"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestOptionUnsupported">
         <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
@@ -319,8 +319,8 @@
       </trans-unit>
       <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
         <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
-        <target state="translated">如需 MTP 程式碼涵蓋範圍，請使用 '--coverage'。這不是 Coverlet 的 'XPlat Code Coverage' 收集器的直接替代品。</target>
-        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+        <target state="needs-review-translation">如需 MTP 程式碼涵蓋範圍，請使用 '--coverage'。這不是 Coverlet 的 'XPlat Code Coverage' 收集器的直接替代品。</target>
+        <note>{Locked="MTP"}{Locked="--coverage"}{Locked="Coverlet"}{Locked="XPlat Code Coverage"}</note>
       </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
@@ -434,18 +434,18 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustNotBeAsyncVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' is declared 'async void'. The platform invokes the hook synchronously, so it would return at its first await: anything it registers after that point would race the test application's own setup, and any failure would be lost. Make the hook synchronous.</source>
-        <target state="translated">延伸模組資訊清單 '{3}' 中所宣告、來自組件 '{2}' 的 '{0}.{1}' 延伸模組掛鉤宣告為 'async void'。平台會同步叫用此掛鉤，因此它會在第一次 await 時返回: 之後註冊的任何內容都會和測試應用程式本身的設定發生競爭，而任何失敗都會遺失。請將此掛鉤改為同步。</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="'async void'"}</note>
+        <target state="needs-review-translation">延伸模組資訊清單 '{3}' 中所宣告、來自組件 '{2}' 的 '{0}.{1}' 延伸模組掛鉤宣告為 'async void'。平台會同步叫用此掛鉤，因此它會在第一次 await 時返回: 之後註冊的任何內容都會和測試應用程式本身的設定發生競爭，而任何失敗都會遺失。請將此掛鉤改為同步。</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {Locked="async void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookMustReturnVoidErrorMessage">
         <source>The '{0}.{1}' extension hook from the assembly '{2}' declared in the extension manifest '{3}' returns '{4}' but must return 'void'. The platform invokes the hook synchronously, so a return value is never observed; a returned task in particular would never be awaited, and its registrations and failures would be lost.</source>
-        <target state="translated">延伸模組資訊清單 '{3}' 中所宣告、來自組件 '{2}' 的 '{0}.{1}' 延伸模組掛鉤傳回 '{4}'，但需傳回 'void'。平台會同步叫用此掛鉤，因此永遠不會觀察到傳回值；尤其是，傳回的工作不會被等待，其註冊和失敗都會遺失。</target>
-        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="'void'"}</note>
+        <target state="needs-review-translation">延伸模組資訊清單 '{3}' 中所宣告、來自組件 '{2}' 的 '{0}.{1}' 延伸模組掛鉤傳回 '{4}'，但需傳回 'void'。平台會同步叫用此掛鉤，因此永遠不會觀察到傳回值；尤其是，傳回的工作不會被等待，其註冊和失敗都會遺失。</target>
+        <note>{0} is the full type name. {1} is the hook method name. {2} is the resolved assembly path. {3} is the manifest file path. {4} is the actual return type name. {Locked="void"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionHookNotFoundErrorMessage">
         <source>The type '{0}' in the assembly '{1}' declared in the extension manifest '{2}' does not expose a 'public static void' method named '{3}' taking an 'ITestApplicationBuilder' and a 'string[]'.</source>
-        <target state="translated">在延伸模組資訊清單 '{2}' 中宣告的組件 '{1}' 內的類型 '{0}' 未公開名為 '{3}' 的 'public static void' 方法，而該方法必須接受 'ITestApplicationBuilder' 和 'string[]'。</target>
-        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="'public static void'"}{Locked="'ITestApplicationBuilder'"}{Locked="'string[]'"}</note>
+        <target state="needs-review-translation">在延伸模組資訊清單 '{2}' 中宣告的組件 '{1}' 內的類型 '{0}' 未公開名為 '{3}' 的 'public static void' 方法，而該方法必須接受 'ITestApplicationBuilder' 和 'string[]'。</target>
+        <note>{0} is the full type name. {1} is the resolved assembly path. {2} is the manifest file path. {3} is the expected method name. {Locked="public static void"}{Locked="ITestApplicationBuilder"}{Locked="string[]"}</note>
       </trans-unit>
       <trans-unit id="DynamicExtensionManifestDirectoryNotReadableErrorMessage">
         <source>The directory '{0}' could not be searched for extension manifests, so the platform cannot tell whether any extension had to be loaded. Remove '{1}' from the command line to skip extension manifest discovery.</source>
@@ -534,8 +534,8 @@
       </trans-unit>
       <trans-unit id="DynamicExtensionsNotSupportedOnCurrentRuntimeErrorMessage">
         <source>The extension manifest '{0}' declares extensions to load, but the current runtime does not support loading assemblies dynamically (for example when published with native AOT). Set the '{1}' property of each extension to 'false', remove the manifest, or remove '{2}' from the command line.</source>
-        <target state="translated">延伸模組資訊清單 '{0}' 宣告了要載入的延伸模組，但目前的執行階段不支援動態載入組件 (例如以原生 AOT 發佈時)。請將每個延伸模組的 '{1}' 屬性設為 'false'，移除資訊清單，或從命令列中移除 '{2}'。</target>
-        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="'false'"}</note>
+        <target state="needs-review-translation">延伸模組資訊清單 '{0}' 宣告了要載入的延伸模組，但目前的執行階段不支援動態載入組件 (例如以原生 AOT 發佈時)。請將每個延伸模組的 '{1}' 屬性設為 'false'，移除資訊清單，或從命令列中移除 '{2}'。</target>
+        <note>{0} is the manifest file path. {1} is the name of the JSON property that disables an extension. {2} is the command line option that enables the feature. {Locked="false"}</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariableProviderFailedWithError">
         <source>Provider '{0}' (UID: {1}) failed with error: {2}</source>
@@ -913,8 +913,8 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
       </trans-unit>
       <trans-unit id="PlatformCommandLineEnableDynamicExtensionsOptionDescription">
         <source>Enable loading test platform extensions declared by '*.testingplatformextensions.json' manifests found next to the test application. Disabled by default.</source>
-        <target state="translated">啟用載入測試應用程式旁 '*.testingplatformextensions.json' 資訊清單所宣告的測試平台延伸模組。預設為停用。</target>
-        <note>{Locked="'*.testingplatformextensions.json'"}</note>
+        <target state="needs-review-translation">啟用載入測試應用程式旁 '*.testingplatformextensions.json' 資訊清單所宣告的測試平台延伸模組。預設為停用。</target>
+        <note>{Locked="*.testingplatformextensions.json"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -952,10 +952,10 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <source>Do not report a non-successful exit value for the specified exit codes.
 For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
 For more information about exit codes, see https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes.</source>
-        <target state="translated">請勿針對指定的結束碼報告非成功的結束值。
+        <target state="needs-review-translation">請勿針對指定的結束碼報告非成功的結束值。
 例如，'--ignore-exit-code 8;9' 會忽略結束碼 8 和 9，並在這些情況下傳回 0。
 如需結束碼的詳細資訊，請參閱 https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes。</target>
-        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
+        <note>{Locked="--ignore-exit-code 8;9"} {Locked="https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>
@@ -1050,15 +1050,15 @@ The default is TestResults in the directory that contains the test application.<
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutArgumentErrorMessage">
         <source>'timeout' option should have one argument as a time value with an explicit unit suffix and a positive numeric value within the supported range (up to ~49.7 days). Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">'timeout' 選項應該有一個引數做為具有明確單位後置詞的時間值，以及在支援的範圍內的正數值 (最多 ~49.7 天)。接受的後置詞為 'ms'/'mil(s)'/'millisecond(s)'、's'/'sec(s)'/'second(s)'、'm'/'min(s)'/'minute(s)'、'h'/'hour(s)' 和 'd'/'day(s)'，例如 '500ms'、'5400s'、'90m'、'1.5h'、'1d'。</target>
-        <note>{Locked="'timeout'"}{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <target state="needs-review-translation">'timeout' 選項應該有一個引數做為具有明確單位後置詞的時間值，以及在支援的範圍內的正數值 (最多 ~49.7 天)。接受的後置詞為 'ms'/'mil(s)'/'millisecond(s)'、's'/'sec(s)'/'second(s)'、'm'/'min(s)'/'minute(s)'、'h'/'hour(s)' 和 'd'/'day(s)'，例如 '500ms'、'5400s'、'90m'、'1.5h'、'1d'。</target>
+        <note>{Locked="timeout"}{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineTimeoutOptionDescription">
         <source>A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</source>
-        <target state="translated">全域測試執行逾時。
+        <target state="needs-review-translation">全域測試執行逾時。
 採用一個引數做為具有明確單位後置詞的時間值。接受的後置詞為 'ms'/'mil(s)'/'millisecond(s)'、's'/'sec(s)'/'second(s)'、'm'/'min(s)'/'minute(s)'、'h'/'hour(s)' 和 'd'/'day(s)'，例如 '500ms'、'5400s'、'90m'、'1.5h'、'1d'。</target>
-        <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
+        <note>{Locked="'ms'"}{Locked="mil(s)"}{Locked="millisecond(s)"}{Locked="'s'"}{Locked="sec(s)"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="min(s)"}{Locked="minute(s)"}{Locked="'h'"}{Locked="hour(s)"}{Locked="'d'"}{Locked="day(s)"}{Locked="500ms"}{Locked="5400s"}{Locked="90m"}{Locked="1.5h"}{Locked="1d"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>
@@ -1294,8 +1294,8 @@ Microsoft 測試平台會收集使用量資料，以協助我們改善您的體�
       </trans-unit>
       <trans-unit id="TestHostControllerConnectionInvalidAuthorizedSecurityIdentityErrorMessage">
         <source>The test host launcher '{0}' (UID: {1}) asked to authorize the security identity '{2}' on the test host controller connection, but only the identity of a single sandboxed application (on Windows, a security identifier of the form 'S-1-15-2-...') can be authorized. Users, groups and the catch-all '{3}' security identifier are never granted access.</source>
-        <target state="translated">測試主機啟動器 '{0}' (UID: {1}) 要求在測試主機控制器連線上授權安全性識別 '{2}'，但只能授權單一受沙箱保護的應用程式身分識別 (在 Windows 上，格式為 'S-1-15-2-...' 的安全性識別碼)。使用者、群組，以及萬用 '{3}' 安全性識別碼，絕不會獲得存取權。</target>
-        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="'S-1-15-2-...'"}</note>
+        <target state="needs-review-translation">測試主機啟動器 '{0}' (UID: {1}) 要求在測試主機控制器連線上授權安全性識別 '{2}'，但只能授權單一受沙箱保護的應用程式身分識別 (在 Windows 上，格式為 'S-1-15-2-...' 的安全性識別碼)。使用者、群組，以及萬用 '{3}' 安全性識別碼，絕不會獲得存取權。</target>
+        <note>{0} is the launcher display name, {1} is the launcher unique identifier, {2} is the rejected security identity, {3} is the well-known 'ALL APPLICATION PACKAGES' security identifier. {Locked="S-1-15-2-..."}</note>
       </trans-unit>
       <trans-unit id="TestHostControllerProcessRestartNotSupportedOnWebAssembly">
         <source>Test host controller extensions that require process restart are not supported on browser/WebAssembly platforms.</source>


### PR DESCRIPTION
## Summary

Backport release-compatible localization metadata fixes from #11075 and #11111:

- update 47 RESX comments so locked tokens occur in the source and surrounding quotation marks remain localizable where safe
- regenerate 117 XLF files across eight owning projects
- exclude four OS-platform analyzer resources that do not exist on `rel/4.4`

The newest OneLoc PR, #11127, has no release-compatible translated targets: 15 resource keys are absent from `rel/4.4`, and the remaining two targets have confirmed review defects.

## Validation

- all 47 resource values match between `main` and `rel/4.4`
- all 611 generated XLF units preserve source and target text
- 571 translated targets move to `needs-review-translation` because their notes changed
- 40 untranslated targets remain `new`
- all 126 changed RESX/XLF files parse successfully
- every remaining lock token occurs verbatim in its source
- `git diff --check` passes