### PR TITLE
Simplify string difference caret eligibility

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.cs
@@ -91,10 +91,12 @@ public sealed partial class Assert
             diagnostic));
     }
 
-    private static bool AreWindowsCaretEligible(StringTokenWindow expectedWindow, StringTokenWindow actualWindow)
+    private static bool DoWindowsAvoidMismatchPlaceholders(StringTokenWindow expectedWindow, StringTokenWindow actualWindow)
         => !expectedWindow.MismatchRequiresPlaceholder
-            && !actualWindow.MismatchRequiresPlaceholder
-            && IsMismatchSuitableForCaret(expectedWindow)
+            && !actualWindow.MismatchRequiresPlaceholder;
+
+    private static bool AreWindowMismatchesSuitableForCaret(StringTokenWindow expectedWindow, StringTokenWindow actualWindow)
+        => IsMismatchSuitableForCaret(expectedWindow)
             && IsMismatchSuitableForCaret(actualWindow);
 
     private static StringDifferenceDiagnostic CreateStringDifferenceDiagnostic(
@@ -119,9 +121,10 @@ public sealed partial class Assert
             int expectedPrefixLength = GetShortPrefixLength(expectedWindow);
             int actualPrefixLength = GetShortPrefixLength(actualWindow);
             bool useCaret =
-                AreWindowsCaretEligible(expectedWindow, actualWindow)
+                DoWindowsAvoidMismatchPlaceholders(expectedWindow, actualWindow)
                 && expectedWindow.IsRetainedPrefixSafe
                 && actualWindow.IsRetainedPrefixSafe
+                && AreWindowMismatchesSuitableForCaret(expectedWindow, actualWindow)
                 && expectedPrefixLength == actualPrefixLength;
 
             string differenceText = useCaret
@@ -134,9 +137,10 @@ public sealed partial class Assert
         StringPreview expectedPreview = CreatePreview(expectedWindow, useInlineMarker: false);
         StringPreview actualPreview = CreatePreview(actualWindow, useInlineMarker: false);
         bool previewUsesCaret =
-            AreWindowsCaretEligible(expectedWindow, actualWindow)
+            DoWindowsAvoidMismatchPlaceholders(expectedWindow, actualWindow)
             && expectedPreview.IsPrefixSafe
             && actualPreview.IsPrefixSafe
+            && AreWindowMismatchesSuitableForCaret(expectedWindow, actualWindow)
             && expectedPreview.MismatchColumn == actualPreview.MismatchColumn;
 
         if (previewUsesCaret)

--- a/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.cs
@@ -91,6 +91,12 @@ public sealed partial class Assert
             diagnostic));
     }
 
+    private static bool AreWindowsCaretEligible(StringTokenWindow expectedWindow, StringTokenWindow actualWindow)
+        => !expectedWindow.MismatchRequiresPlaceholder
+            && !actualWindow.MismatchRequiresPlaceholder
+            && IsMismatchSuitableForCaret(expectedWindow)
+            && IsMismatchSuitableForCaret(actualWindow);
+
     private static StringDifferenceDiagnostic CreateStringDifferenceDiagnostic(
         string expected,
         string actual,
@@ -113,12 +119,9 @@ public sealed partial class Assert
             int expectedPrefixLength = GetShortPrefixLength(expectedWindow);
             int actualPrefixLength = GetShortPrefixLength(actualWindow);
             bool useCaret =
-                !expectedWindow.MismatchRequiresPlaceholder
-                && !actualWindow.MismatchRequiresPlaceholder
+                AreWindowsCaretEligible(expectedWindow, actualWindow)
                 && expectedWindow.IsRetainedPrefixSafe
                 && actualWindow.IsRetainedPrefixSafe
-                && IsMismatchSuitableForCaret(expectedWindow)
-                && IsMismatchSuitableForCaret(actualWindow)
                 && expectedPrefixLength == actualPrefixLength;
 
             string differenceText = useCaret
@@ -131,12 +134,9 @@ public sealed partial class Assert
         StringPreview expectedPreview = CreatePreview(expectedWindow, useInlineMarker: false);
         StringPreview actualPreview = CreatePreview(actualWindow, useInlineMarker: false);
         bool previewUsesCaret =
-            !expectedWindow.MismatchRequiresPlaceholder
-            && !actualWindow.MismatchRequiresPlaceholder
+            AreWindowsCaretEligible(expectedWindow, actualWindow)
             && expectedPreview.IsPrefixSafe
             && actualPreview.IsPrefixSafe
-            && IsMismatchSuitableForCaret(expectedWindow)
-            && IsMismatchSuitableForCaret(actualWindow)
             && expectedPreview.MismatchColumn == actualPreview.MismatchColumn;
 
         if (previewUsesCaret)

--- a/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.cs
@@ -91,11 +91,11 @@ public sealed partial class Assert
             diagnostic));
     }
 
-    private static bool DoWindowsAvoidMismatchPlaceholders(StringTokenWindow expectedWindow, StringTokenWindow actualWindow)
+    private static bool AreWindowsMismatchPlaceholderFree(StringTokenWindow expectedWindow, StringTokenWindow actualWindow)
         => !expectedWindow.MismatchRequiresPlaceholder
             && !actualWindow.MismatchRequiresPlaceholder;
 
-    private static bool AreWindowMismatchesSuitableForCaret(StringTokenWindow expectedWindow, StringTokenWindow actualWindow)
+    private static bool AreMismatchesSuitableForCaret(StringTokenWindow expectedWindow, StringTokenWindow actualWindow)
         => IsMismatchSuitableForCaret(expectedWindow)
             && IsMismatchSuitableForCaret(actualWindow);
 
@@ -121,10 +121,10 @@ public sealed partial class Assert
             int expectedPrefixLength = GetShortPrefixLength(expectedWindow);
             int actualPrefixLength = GetShortPrefixLength(actualWindow);
             bool useCaret =
-                DoWindowsAvoidMismatchPlaceholders(expectedWindow, actualWindow)
+                AreWindowsMismatchPlaceholderFree(expectedWindow, actualWindow)
                 && expectedWindow.IsRetainedPrefixSafe
                 && actualWindow.IsRetainedPrefixSafe
-                && AreWindowMismatchesSuitableForCaret(expectedWindow, actualWindow)
+                && AreMismatchesSuitableForCaret(expectedWindow, actualWindow)
                 && expectedPrefixLength == actualPrefixLength;
 
             string differenceText = useCaret
@@ -137,10 +137,10 @@ public sealed partial class Assert
         StringPreview expectedPreview = CreatePreview(expectedWindow, useInlineMarker: false);
         StringPreview actualPreview = CreatePreview(actualWindow, useInlineMarker: false);
         bool previewUsesCaret =
-            DoWindowsAvoidMismatchPlaceholders(expectedWindow, actualWindow)
+            AreWindowsMismatchPlaceholderFree(expectedWindow, actualWindow)
             && expectedPreview.IsPrefixSafe
             && actualPreview.IsPrefixSafe
-            && AreWindowMismatchesSuitableForCaret(expectedWindow, actualWindow)
+            && AreMismatchesSuitableForCaret(expectedWindow, actualWindow)
             && expectedPreview.MismatchColumn == actualPreview.MismatchColumn;
 
         if (previewUsesCaret)


### PR DESCRIPTION
Extract the caret-eligibility conditions shared by the preview and non-preview string difference paths into a named helper. This removes duplicated logic while preserving the existing prefix-safety and mismatch-alignment requirements.

Closes #11146