### PR TITLE
Relax MSTEST0032 for enum value assertions

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
@@ -69,6 +69,7 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
             "IsTrue" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
             "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
             "AreEqual" => !AssertConditionAnalyzerHelper.HasNonDefaultEqualityComparerArgument(operation)
+                && !IsEnumUnderlyingValueContractAssertion(operation)
                 && (AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
                     || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.ExpectedParameterName)),
             "AreNotEqual" => !AssertConditionAnalyzerHelper.HasNonDefaultEqualityComparerArgument(operation)
@@ -77,5 +78,65 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
             "IsNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
             "IsNotNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { } valueArgumentOperation && AssertConditionAnalyzerHelper.IsNotNullableType(valueArgumentOperation),
             _ => false,
+        };
+
+    private static bool IsEnumUnderlyingValueContractAssertion(IInvocationOperation operation)
+    {
+        IOperation? expectedArgument = operation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == AssertConditionAnalyzerHelper.ExpectedParameterName)?.Value;
+        IOperation? actualArgument = operation.Arguments.FirstOrDefault(argument => argument.Parameter?.Name == AssertConditionAnalyzerHelper.ActualParameterName)?.Value;
+
+        return expectedArgument is not null
+            && actualArgument is not null
+            && ((IsNumericLiteral(expectedArgument) && IsEnumMemberConvertedToUnderlyingType(actualArgument))
+                || (IsEnumMemberConvertedToUnderlyingType(expectedArgument) && IsNumericLiteral(actualArgument)));
+    }
+
+    private static bool IsNumericLiteral(IOperation operation)
+        => WalkDownImplicitConversionsAndParentheses(operation) switch
+        {
+            ILiteralOperation { Type.SpecialType: var specialType } => IsIntegralNumericType(specialType),
+            IUnaryOperation { OperatorKind: UnaryOperatorKind.Plus or UnaryOperatorKind.Minus, Operand: { } operand } => IsNumericLiteral(operand),
+            _ => false,
+        };
+
+    private static bool IsIntegralNumericType(SpecialType specialType)
+        => specialType is SpecialType.System_SByte
+            or SpecialType.System_Byte
+            or SpecialType.System_Int16
+            or SpecialType.System_UInt16
+            or SpecialType.System_Int32
+            or SpecialType.System_UInt32
+            or SpecialType.System_Int64
+            or SpecialType.System_UInt64;
+
+    private static bool IsEnumMemberConvertedToUnderlyingType(IOperation operation)
+    {
+        operation = WalkDownImplicitConversionsAndParentheses(operation);
+        if (operation is not IConversionOperation
+            {
+                IsImplicit: false,
+                Type: { } convertedType,
+                Operand: { } operand,
+            })
+        {
+            return false;
+        }
+
+        operand = WalkDownImplicitConversionsAndParentheses(operand);
+        return GetEnumUnderlyingType(operand) is { } underlyingType
+            && SymbolEqualityComparer.Default.Equals(convertedType, underlyingType);
+    }
+
+    private static ITypeSymbol? GetEnumUnderlyingType(IOperation operation)
+        => operation is IFieldReferenceOperation { Field: { HasConstantValue: true, ContainingType: { TypeKind: TypeKind.Enum } enumType } }
+            ? enumType.EnumUnderlyingType
+            : null;
+
+    private static IOperation WalkDownImplicitConversionsAndParentheses(IOperation operation)
+        => operation switch
+        {
+            IConversionOperation { IsImplicit: true } conversion => WalkDownImplicitConversionsAndParentheses(conversion.Operand),
+            IParenthesizedOperation parenthesizedOperation => WalkDownImplicitConversionsAndParentheses(parenthesizedOperation.Operand),
+            _ => operation,
         };
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -5,6 +5,10 @@ using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
     MSTest.Analyzers.ReviewAlwaysTrueAssertConditionAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
+using VerifyVB = MSTest.Analyzers.Test.VisualBasicCodeFixVerifier<
+    MSTest.Analyzers.ReviewAlwaysTrueAssertConditionAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
 namespace MSTest.Analyzers.Test;
 
 [TestClass]
@@ -933,6 +937,169 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
                 public void TestMethod()
                 {
                     [|Assert.AreEqual(true, true)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualPinsEnumUnderlyingValue_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public enum ReportDumpType
+            {
+                Micro = 1,
+                Mini = 2,
+                Heap = 3,
+                All = -1,
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.AreEqual(1, (int)ReportDumpType.Micro);
+                    Assert.AreEqual((int)ReportDumpType.Mini, 2);
+                    Assert.AreEqual(actual: (int)ReportDumpType.Heap, expected: 3);
+                    Assert.AreEqual(-1, (int)ReportDumpType.All);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualPinsEnumsWithAllUnderlyingTypes_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public enum SByteEnum : sbyte { Value = 1 }
+            public enum ByteEnum : byte { Value = 1 }
+            public enum ShortEnum : short { Value = 1 }
+            public enum UShortEnum : ushort { Value = 1 }
+            public enum IntEnum : int { Value = 1 }
+            public enum UIntEnum : uint { Value = 1 }
+            public enum LongEnum : long { Value = 1 }
+            public enum ULongEnum : ulong { Value = 1 }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.AreEqual<sbyte>(1, (sbyte)SByteEnum.Value);
+                    Assert.AreEqual<byte>(1, (byte)ByteEnum.Value);
+                    Assert.AreEqual<short>(1, (short)ShortEnum.Value);
+                    Assert.AreEqual<ushort>(1, (ushort)UShortEnum.Value);
+                    Assert.AreEqual(1, (int)IntEnum.Value);
+                    Assert.AreEqual(1U, (uint)UIntEnum.Value);
+                    Assert.AreEqual(1L, (long)LongEnum.Value);
+                    Assert.AreEqual(1UL, (ulong)ULongEnum.Value);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualPinsEnumUnderlyingValueInVisualBasic_NoDiagnostic()
+    {
+        string code = """
+            Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+            Public Enum ReportDumpType
+                Micro = 1
+                All = -1
+            End Enum
+
+            <TestClass>
+            Public Class MyTestClass
+                <TestMethod>
+                Public Sub TestMethod()
+                    Assert.AreEqual(1, CInt(ReportDumpType.Micro))
+                    Assert.AreEqual(-1, CInt(ReportDumpType.All))
+                End Sub
+            End Class
+            """;
+
+        await VerifyVB.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualUsesOtherConstantExpressions_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private const int Field = 1;
+
+                [TestMethod]
+                public void TestMethod()
+                {
+                    const int local = 1;
+
+                    [|Assert.AreEqual(1, 1)|];
+                    [|Assert.AreEqual(-1, -1)|];
+                    [|Assert.AreEqual(+1, +1)|];
+                    [|Assert.AreEqual((byte)1, (byte)1)|];
+                    [|Assert.AreEqual(1, (int)1)|];
+                    [|Assert.AreEqual(local, 1)|];
+                    [|Assert.AreEqual(Field, 1)|];
+                    [|Assert.AreEqual(1 + 1, 2)|];
+                    [|Assert.AreEqual('a', 'a')|];
+                    [|Assert.AreEqual(1.0, 1.0)|];
+                    [|Assert.AreEqual(1m, 1m)|];
+                    [|Assert.AreEqual("value", "value")|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualUsesOtherEnumConstantExpressions_Diagnostic()
+    {
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [Flags]
+            public enum Options
+            {
+                None = 0,
+                First = 1,
+                Second = 2,
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private const Options Field = Options.First;
+
+                [TestMethod]
+                public void TestMethod()
+                {
+                    const Options local = Options.First;
+
+                    [|Assert.AreEqual(Options.First, Options.First)|];
+                    [|Assert.AreEqual((int)Options.First, (int)Options.First)|];
+                    [|Assert.AreEqual(1, (int)local)|];
+                    [|Assert.AreEqual(1, (int)Field)|];
+                    [|Assert.AreEqual(3, (int)(Options.First | Options.Second))|];
                 }
             }
             """;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1056,6 +1056,7 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
                     [|Assert.AreEqual(+1, +1)|];
                     [|Assert.AreEqual((byte)1, (byte)1)|];
                     [|Assert.AreEqual(1, (int)1)|];
+                    [|Assert.AreEqual<object>((int)1, (int)1)|];
                     [|Assert.AreEqual(local, 1)|];
                     [|Assert.AreEqual(Field, 1)|];
                     [|Assert.AreEqual(1 + 1, 2)|];
@@ -1100,6 +1101,8 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
                     [|Assert.AreEqual(1, (int)local)|];
                     [|Assert.AreEqual(1, (int)Field)|];
                     [|Assert.AreEqual(3, (int)(Options.First | Options.Second))|];
+                    [|Assert.AreEqual<long>(1, (long)Options.First)|];
+                    [|Assert.AreEqual<object>((int)1, (int)Options.First)|];
                 }
             }
             """;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -5,10 +5,6 @@ using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
     MSTest.Analyzers.ReviewAlwaysTrueAssertConditionAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
-using VerifyVB = MSTest.Analyzers.Test.VisualBasicCodeFixVerifier<
-    MSTest.Analyzers.ReviewAlwaysTrueAssertConditionAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-
 namespace MSTest.Analyzers.Test;
 
 [TestClass]
@@ -1009,30 +1005,6 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
             """;
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
-    }
-
-    [TestMethod]
-    public async Task WhenAssertAreEqualPinsEnumUnderlyingValueInVisualBasic_NoDiagnostic()
-    {
-        string code = """
-            Imports Microsoft.VisualStudio.TestTools.UnitTesting
-
-            Public Enum ReportDumpType
-                Micro = 1
-                All = -1
-            End Enum
-
-            <TestClass>
-            Public Class MyTestClass
-                <TestMethod>
-                Public Sub TestMethod()
-                    Assert.AreEqual(1, CInt(ReportDumpType.Micro))
-                    Assert.AreEqual(-1, CInt(ReportDumpType.All))
-                End Sub
-            End Class
-            """;
-
-        await VerifyVB.VerifyCodeFixAsync(code, code);
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -965,6 +965,7 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
                     Assert.AreEqual(actual: (int)ReportDumpType.Heap, expected: 3);
                     Assert.AreEqual(-1, (int)ReportDumpType.All);
                     Assert.AreEqual(+1, (int)ReportDumpType.Micro);
+                    Assert.AreEqual((1), ((int)ReportDumpType.Micro));
                 }
             }
             """;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -964,6 +964,7 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
                     Assert.AreEqual((int)ReportDumpType.Mini, 2);
                     Assert.AreEqual(actual: (int)ReportDumpType.Heap, expected: 3);
                     Assert.AreEqual(-1, (int)ReportDumpType.All);
+                    Assert.AreEqual(+1, (int)ReportDumpType.Micro);
                 }
             }
             """;


### PR DESCRIPTION
`MSTEST0032` currently treats an enum member cast to its underlying numeric type as an ordinary compile-time constant, which prevents tests from directly pinning an enum's documented numeric contract.

This change excludes `Assert.AreEqual` from the diagnostic only when one operand is an integral numeric literal and the other is an enum member explicitly converted to that enum's exact underlying type. Other constant comparisons, casts, named constants, arithmetic expressions, and enum expressions remain diagnostic.

The regression matrix covers C# positive and negative values, unary plus, argument ordering, named arguments, every integral enum underlying type, and nearby non-enum cases.