### PR TITLE
Hide skipped test details in public CI

### DIFF
--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -31,7 +31,7 @@ steps:
 # by Microsoft.Testing.Platform actually reaches the live build log; with the default (true), the
 # output is buffered into a per-module .log file and only surfaced on failure, so no live progress
 # is visible during long-running test sessions.
-- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false ${{ parameters.testFailureTrailer }}
+- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --show-test-results failed ${{ parameters.testFailureTrailer }}
   name: Test
   displayName: Test
   condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/eng/pipelines/steps/test-windows-app-model.yml
+++ b/eng/pipelines/steps/test-windows-app-model.yml
@@ -23,10 +23,10 @@ steps:
 - script: dotnet build test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-incremental -bl:artifacts\log\$(_BuildConfig)\PackagedWinUI.binlog
   displayName: 'Build packaged WinUI acceptance tests'
 
-- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "FullyQualifiedName~WindowsApplicationModelPackageTests" -p:UsingDotNetTest=true -p:ArtifactsTestResultsDir=$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\WindowsApplicationModelPackageContracts
+- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "FullyQualifiedName~WindowsApplicationModelPackageTests" -p:UsingDotNetTest=true -p:ArtifactsTestResultsDir=$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\WindowsApplicationModelPackageContracts --show-test-results failed
   displayName: 'Test packed Windows application-model contracts'
 
-- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true
+- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true --show-test-results failed
   displayName: 'Test real Modern and classic UWP applications'
   env:
     TESTFX_RUN_WINDOWS_APP_MODEL_TESTS: 1
@@ -60,7 +60,7 @@ steps:
   env:
     WINAPP_CLI_TELEMETRY_OPTOUT: 1
 
-- script: dotnet test test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true
+- script: dotnet test test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true --show-test-results failed
   displayName: 'Test packaged WinUI and WinApp CLI interoperability'
   env:
     TESTFX_RUN_WINDOWS_APP_MODEL_TESTS: 1

--- a/eng/pipelines/steps/test-windows-configuration-tests.yml
+++ b/eng/pipelines/steps/test-windows-configuration-tests.yml
@@ -27,7 +27,7 @@ steps:
 - ${{ if eq(parameters.enableAffectedTests, false) }}:
   - script: |
       echo ##vso[task.setvariable variable=PublishCoverageReport]true
-      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
+      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --show-test-results failed
     name: Test
     displayName: Test
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), ne(variables._XmlDocsOnly, 'true'))
@@ -52,7 +52,7 @@ steps:
 
   - script: |
       echo ##vso[task.setvariable variable=PublishCoverageReport]true
-      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --collect-test-map
+      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --show-test-results failed --collect-test-map
     name: Test
     displayName: Test and collect affected-test map
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), ne(variables._XmlDocsOnly, 'true'))
@@ -72,7 +72,7 @@ steps:
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), ne(variables._XmlDocsOnly, 'true'), eq(variables['Build.Reason'], 'PullRequest'))
 
   - pwsh: |
-      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --affected-tests
+      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --show-test-results failed --affected-tests
       $exitCode = $LASTEXITCODE
       if ($exitCode -eq 0) {
         Write-Host "##vso[task.setvariable variable=AffectedTestsSucceeded]true"
@@ -104,7 +104,7 @@ steps:
           Remove-Item -Force
       }
 
-      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
+      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --show-test-results failed
       exit $LASTEXITCODE
     name: Test
     displayName: Test (affected-test fallback)
@@ -119,7 +119,7 @@ steps:
 # The Debug leg exists to exercise DEBUG-conditional product code and tests. The Release integration suite
 # already creates child test assets in both configurations, so repeating that suite in Debug is redundant.
 # --test-modules bypasses MSBuild evaluation, so explicitly provide the reporting and diagnostics arguments.
-- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) $(_DebugUnitTestReportArgs) --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig) --diagnostic-verbosity trace
+- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.exe" --results-directory $(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig) $(_DebugUnitTestReportArgs) --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig) --diagnostic-verbosity trace --show-test-results failed
   name: TestDebug
   displayName: Test (unit tests only)
   condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'), ne(variables._XmlDocsOnly, 'true'))

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -51,7 +51,9 @@
 
   <ItemGroup>
     <!-- Persist this preference into each test host so direct solution and test-module runs also honor it.
-         Explicit command-line values can still override the default. Skipped tests remain in summaries and reports. -->
+         Explicit command-line values can still override the default. The public CI commands also pass the
+         option explicitly because the outer dotnet test reporter cannot consume per-project passive defaults.
+         Skipped tests remain in summaries and reports. -->
     <TestingPlatformCommandLineOptionDefault Include="show-test-results" Value="failed" />
   </ItemGroup>
 


### PR DESCRIPTION
Public CI still printed full skipped-test result blocks even though each test host loaded the repository's `show-test-results=failed` passive default. The outer `dotnet test` reporter does not consume per-project passive defaults, so the setting never controlled the output visible in Azure Pipelines.

Pass `--show-test-results failed` explicitly to every public-CI `dotnet test` entry point, including Windows Release, affected-test and fallback paths, Debug test modules, Linux/macOS, and Windows application-model tests. The passive default remains in place for direct test-host runs, while skipped counts and report data remain available in summaries and artifacts.