### PR TITLE
Declare testing platform capabilities in props

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.props
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.props
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
   <ItemGroup>
+    <!-- Declare our capabilities early so project-system consumers can observe them during evaluation. -->
+    <_TestingPlatformProjectCapability Include="TestingPlatformServer">
+      <TestingPlatformCapabilityOwner>Microsoft.Testing.Platform</TestingPlatformCapabilityOwner>
+    </_TestingPlatformProjectCapability>
+
+    <!-- Old capability expected by VS/VSCode -->
+    <_TestingPlatformProjectCapability Include="TestContainer">
+      <TestingPlatformCapabilityOwner>Microsoft.Testing.Platform</TestingPlatformCapabilityOwner>
+    </_TestingPlatformProjectCapability>
+
+    <ProjectCapability Include="@(_TestingPlatformProjectCapability)" />
+
     <!-- For VS Test Explorer -->
     <ProjectCapability Include="TestingPlatformServer.ExitOnProcessExitCapability">
       <Description>--exit-on-process-exit: Close the test process if specific process exits. Process PID must be provided.</Description>

--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.props
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.props
@@ -1,13 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
   <!-- Declare our capabilities early so project-system consumers can observe them during evaluation. -->
-  <!-- DisableTestingPlatformServerCapability or IsTestingPlatformApplication may be set by TestAdapter targets. -->
-  <!-- MSBuild evaluates all properties before items, so these conditions observe their final values. -->
-  <ItemGroup Condition=" '$(DisableTestingPlatformServerCapability)' != 'true' AND '$(IsTestingPlatformApplication)' == 'true' ">
-    <ProjectCapability Include="TestingPlatformServer" />
+  <ItemGroup>
+    <_TestingPlatformProjectCapability Include="TestingPlatformServer">
+      <TestingPlatformCapabilityOwner>Microsoft.Testing.Platform</TestingPlatformCapabilityOwner>
+    </_TestingPlatformProjectCapability>
 
     <!-- Old capability expected by VS/VSCode -->
-    <ProjectCapability Include="TestContainer" />
+    <_TestingPlatformProjectCapability Include="TestContainer">
+      <TestingPlatformCapabilityOwner>Microsoft.Testing.Platform</TestingPlatformCapabilityOwner>
+    </_TestingPlatformProjectCapability>
+
+    <ProjectCapability Include="@(_TestingPlatformProjectCapability)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.props
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.props
@@ -1,18 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
-  <ItemGroup>
-    <!-- Declare our capabilities early so project-system consumers can observe them during evaluation. -->
-    <_TestingPlatformProjectCapability Include="TestingPlatformServer">
-      <TestingPlatformCapabilityOwner>Microsoft.Testing.Platform</TestingPlatformCapabilityOwner>
-    </_TestingPlatformProjectCapability>
+  <!-- Declare our capabilities early so project-system consumers can observe them during evaluation. -->
+  <!-- DisableTestingPlatformServerCapability or IsTestingPlatformApplication may be set by TestAdapter targets. -->
+  <!-- MSBuild evaluates all properties before items, so these conditions observe their final values. -->
+  <ItemGroup Condition=" '$(DisableTestingPlatformServerCapability)' != 'true' AND '$(IsTestingPlatformApplication)' == 'true' ">
+    <ProjectCapability Include="TestingPlatformServer" />
 
     <!-- Old capability expected by VS/VSCode -->
-    <_TestingPlatformProjectCapability Include="TestContainer">
-      <TestingPlatformCapabilityOwner>Microsoft.Testing.Platform</TestingPlatformCapabilityOwner>
-    </_TestingPlatformProjectCapability>
+    <ProjectCapability Include="TestContainer" />
+  </ItemGroup>
 
-    <ProjectCapability Include="@(_TestingPlatformProjectCapability)" />
-
+  <ItemGroup>
     <!-- For VS Test Explorer -->
     <ProjectCapability Include="TestingPlatformServer.ExitOnProcessExitCapability">
       <Description>--exit-on-process-exit: Close the test process if specific process exits. Process PID must be provided.</Description>

--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
@@ -5,6 +5,20 @@
     <IsTestingPlatformApplication Condition=" '$(IsTestingPlatformApplication)' == '' ">true</IsTestingPlatformApplication>
   </PropertyGroup>
 
+  <!-- Remove the capabilities declared in props when this project does not use Testing Platform. -->
+  <!-- Note: DisableTestingPlatformServerCapability or IsTestingPlatformApplication may be set by TestAdapter targets -->
+  <!-- While TestAdapter targets file is imported *after* this file, MSBuild evaluates properties -->
+  <!-- first, then items. So, we will be able to pick up the correct value here. -->
+  <ItemGroup Condition=" '$(DisableTestingPlatformServerCapability)' == 'true' OR '$(IsTestingPlatformApplication)' != 'true' ">
+    <!-- Preserve same-named capabilities that were contributed by another package or the project. -->
+    <_TestingPlatformProjectCapabilityToPreserve
+      Include="@(ProjectCapability->WithMetadataValue('TestingPlatformCapabilityOwner', '')->WithMetadataValue('Identity', 'TestingPlatformServer'))" />
+    <_TestingPlatformProjectCapabilityToPreserve
+      Include="@(ProjectCapability->WithMetadataValue('TestingPlatformCapabilityOwner', '')->WithMetadataValue('Identity', 'TestContainer'))" />
+    <ProjectCapability Remove="TestingPlatformServer;TestContainer" />
+    <ProjectCapability Include="@(_TestingPlatformProjectCapabilityToPreserve)" />
+  </ItemGroup>
+
   <!-- Add assembly attribute metadata for reflection usage. -->
   <!-- This is an inner-build-only concern: in the cross-targeting (outer) build of a multi-targeted -->
   <!-- project, '$(TargetFramework)' is empty and no assembly is produced, so AssemblyMetadata items -->

--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
@@ -5,15 +5,12 @@
     <IsTestingPlatformApplication Condition=" '$(IsTestingPlatformApplication)' == '' ">true</IsTestingPlatformApplication>
   </PropertyGroup>
 
-  <!-- Declare our capability to Visual Studio/Visual Studio Code -->
+  <!-- Remove the capabilities declared in props when this project does not use Testing Platform. -->
   <!-- Note: DisableTestingPlatformServerCapability or IsTestingPlatformApplication may be set by TestAdapter targets -->
   <!-- While TestAdapter targets file is imported *after* this file, MSBuild evaluates properties -->
   <!-- first, then items. So, we will be able to pick up the correct value here. -->
-  <ItemGroup Condition=" '$(DisableTestingPlatformServerCapability)' != 'true' AND '$(IsTestingPlatformApplication)' == 'true' ">
-    <ProjectCapability Include="TestingPlatformServer" />
-
-    <!-- Old capability expected by VS/VSCode -->
-    <ProjectCapability Include="TestContainer" />
+  <ItemGroup Condition=" '$(DisableTestingPlatformServerCapability)' == 'true' OR '$(IsTestingPlatformApplication)' != 'true' ">
+    <ProjectCapability Remove="@(_TestingPlatformProjectCapability)" MatchOnMetadata="TestingPlatformCapabilityOwner" />
   </ItemGroup>
 
   <!-- Add assembly attribute metadata for reflection usage. -->

--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
@@ -5,14 +5,6 @@
     <IsTestingPlatformApplication Condition=" '$(IsTestingPlatformApplication)' == '' ">true</IsTestingPlatformApplication>
   </PropertyGroup>
 
-  <!-- Remove the capabilities declared in props when this project does not use Testing Platform. -->
-  <!-- Note: DisableTestingPlatformServerCapability or IsTestingPlatformApplication may be set by TestAdapter targets -->
-  <!-- While TestAdapter targets file is imported *after* this file, MSBuild evaluates properties -->
-  <!-- first, then items. So, we will be able to pick up the correct value here. -->
-  <ItemGroup Condition=" '$(DisableTestingPlatformServerCapability)' == 'true' OR '$(IsTestingPlatformApplication)' != 'true' ">
-    <ProjectCapability Remove="@(_TestingPlatformProjectCapability)" MatchOnMetadata="TestingPlatformCapabilityOwner" />
-  </ItemGroup>
-
   <!-- Add assembly attribute metadata for reflection usage. -->
   <!-- This is an inner-build-only concern: in the cross-targeting (outer) build of a multi-targeted -->
   <!-- project, '$(TargetFramework)' is empty and no assembly is produced, so AssemblyMetadata items -->

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RunnerTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RunnerTests.cs
@@ -124,7 +124,12 @@ return await app.RunAsync();
   <ProjectCapability Include="TestContainer" />
 </ItemGroup>
 <Target Name="PrintProjectCapabilities" BeforeTargets="CoreCompile">
+  <ItemGroup>
+    <_TestingPlatformOwnedTestContainerCapability
+      Include="@(ProjectCapability->WithMetadataValue('TestingPlatformCapabilityOwner', 'Microsoft.Testing.Platform')->WithMetadataValue('Identity', 'TestContainer'))" />
+  </ItemGroup>
   <Message Text="ProjectCapabilitiesEvaluated" Importance="high" />
+  <Message Text="TestingPlatformOwnedTestContainerCapabilityCount=@(_TestingPlatformOwnedTestContainerCapability->Count())" Importance="high" />
   <Message Text="ProjectCapability=[%(ProjectCapability.Identity)]" Importance="high" />
 </Target>
 </Project>
@@ -133,6 +138,7 @@ return await app.RunAsync();
         DotnetMuxerResult result = await DotnetCli.RunAsync($"{verb} {generator.TargetAssetPath} -c {buildConfiguration} -r {RID} ", cancellationToken: TestContext.CancellationToken);
 
         result.AssertOutputContains("ProjectCapabilitiesEvaluated");
+        result.AssertOutputContains("TestingPlatformOwnedTestContainerCapabilityCount=0");
         result.AssertOutputContains("ProjectCapability=[TestContainer]");
         result.AssertOutputDoesNotContain("ProjectCapability=[TestingPlatformServer]");
     }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RunnerTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RunnerTests.cs
@@ -118,12 +118,55 @@ return await app.RunAsync();
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
                 .PatchCodeWithReplace("$EnableMSTestRunner$", string.Empty)
                 .PatchCodeWithReplace("$OutputType$", string.Empty)
-                .PatchCodeWithReplace("$Extra$", string.Empty));
+                .PatchCodeWithReplace("$Extra$", string.Empty)
+                .PatchCodeWithReplace("</Project>", """
+<ItemGroup>
+  <ProjectCapability Include="TestContainer" />
+</ItemGroup>
+<Target Name="PrintProjectCapabilities" BeforeTargets="CoreCompile">
+  <Message Text="ProjectCapabilitiesEvaluated" Importance="high" />
+  <Message Text="ProjectCapability=[%(ProjectCapability.Identity)]" Importance="high" />
+</Target>
+</Project>
+"""));
 
         DotnetMuxerResult result = await DotnetCli.RunAsync($"{verb} {generator.TargetAssetPath} -c {buildConfiguration} -r {RID} ", cancellationToken: TestContext.CancellationToken);
 
-        Build binLog = BinlogReader.Read(result.BinlogPath!);
-        Assert.DoesNotContain(x => x.Title.Contains("ProjectCapability") && x.Children.Any(c => ((Item)c).Name == "TestingPlatformServer"), binLog.FindChildrenRecursive<AddItem>());
+        result.AssertOutputContains("ProjectCapabilitiesEvaluated");
+        result.AssertOutputContains("ProjectCapability=[TestContainer]");
+        result.AssertOutputDoesNotContain("ProjectCapability=[TestingPlatformServer]");
+    }
+
+    [TestMethod]
+    public async SystemTask TestingPlatformCapabilities_Can_Be_Removed_From_Project()
+    {
+        using TestAsset generator = await TestAsset.GenerateAssetAsync(
+            AssetName,
+            CurrentMSTestSourceCode
+                .PatchCodeWithReplace("$TargetFramework$", $"<TargetFramework>{TargetFrameworks.NetCurrent}</TargetFramework>")
+                .PatchCodeWithReplace("$MicrosoftNETTestSdkVersion$", MicrosoftNETTestSdkVersion)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+                .PatchCodeWithReplace("$EnableMSTestRunner$", "<EnableMSTestRunner>true</EnableMSTestRunner>")
+                .PatchCodeWithReplace("$OutputType$", "<OutputType>Exe</OutputType>")
+                .PatchCodeWithReplace("$Extra$", string.Empty)
+                .PatchCodeWithReplace("</Project>", """
+<ItemGroup>
+  <ProjectCapability Remove="TestingPlatformServer;TestContainer" />
+</ItemGroup>
+<Target Name="PrintProjectCapabilities" BeforeTargets="CoreCompile">
+  <Message Text="ProjectCapabilitiesEvaluated" Importance="high" />
+  <Message Text="ProjectCapability=[%(ProjectCapability.Identity)]" Importance="high" />
+</Target>
+</Project>
+"""));
+
+        DotnetMuxerResult result = await DotnetCli.RunAsync(
+            $"build {generator.TargetAssetPath} -c Debug -r {RID}",
+            cancellationToken: TestContext.CancellationToken);
+
+        result.AssertOutputContains("ProjectCapabilitiesEvaluated");
+        result.AssertOutputDoesNotContain("ProjectCapability=[TestingPlatformServer]");
+        result.AssertOutputDoesNotContain("ProjectCapability=[TestContainer]");
     }
 
     public TestContext TestContext { get; set; }


### PR DESCRIPTION
## Why

A new Visual Studio integration is asking whether the Testing Platform capabilities can be declared from the package props phase while retaining the existing project opt-out behavior. Existing Visual Studio capability discovery continues to work with evaluation-time items declared in `.targets`; this change only tests the requested earlier placement.

## What changed

- Declare `TestingPlatformServer` and the legacy `TestContainer` capability in `Microsoft.Testing.Platform.props`.
- Remove both capabilities in `Microsoft.Testing.Platform.targets` when Testing Platform is disabled.
- Keep project-authored `<ProjectCapability Remove="..." />` overrides effective because the capabilities are no longer added after the project body.
- Add acceptance coverage for default capability declaration, adapter-driven removal, and explicit project removal.

## Validation

- `build.cmd -pack -bl`
- Default MTP capability acceptance coverage: 12 cases passed.
- Adapter-driven removal acceptance coverage: 12 cases passed.
- Explicit project removal acceptance coverage: 1 case passed.