### PR TITLE
Improve TestFx code review guidance

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -103,9 +103,9 @@ must meet the concrete-scenario and observable-consequence bar in
   explicit invariant throws into silent fallbacks, warnings, or empty returns
   without a concrete external trigger or failing test that disproves the
   invariant.
-- Workflow, script, issue-template, and policy changes must use native GitHub
-  Issue Types and must not introduce the deprecated `type/bug`, `type/feature`,
-  or `type/task` labels.
+- Workflow, script, issue-template, and policy changes that create or triage
+  issues must use native GitHub Issue Types and must not introduce the
+  deprecated `type/bug`, `type/feature`, or `type/task` labels.
 - Do not allow untracked `TODO` comments.
 
 ## Security checks

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -23,10 +23,52 @@ tests to understand the changed behavior before commenting.
    - `src/Package/MSTest.Sdk`, `eng`, and MSBuild files: build and packaging.
 2. Trace each behavior change through its callers, tests, target frameworks,
    shipped packages, and linked source files.
-3. Check changed tests against the test-review guidance below.
-4. Report only actionable findings on changed lines. Prefer a small number of
+3. Compare the PR title and description with the actual diff. Verify that the
+   stated motivation, behavior change, compatibility impact, and validation
+   match what the code does.
+4. Check changed tests against the test-review guidance below.
+5. Report only actionable findings caused by the PR. Prefer a small number of
    high-confidence findings over broad summaries or praise.
-5. If the change is correct, do not invent a finding merely to leave feedback.
+6. If the change is correct, do not invent a finding merely to leave feedback.
+
+## PR scope and review depth
+
+Be constructively critical. Challenge the change's assumptions, failure modes,
+and claimed validation rather than accepting the implementation or description
+at face value. Criticism must still identify concrete evidence and impact; do
+not manufacture objections for the sake of sounding rigorous. Every criticism
+must meet the concrete-scenario and observable-consequence bar in
+`Finding quality`.
+
+- Check whether the PR combines independent features, refactors, fixes, or
+  formatting changes that have different motivations or could be reviewed,
+  reverted, and shipped separately. When this materially obscures behavior or
+  increases review risk, recommend splitting the PR and identify the distinct
+  change groups.
+- Check that every material diff is explained by the PR description and that
+  every claimed behavior is implemented. Flag hidden scope, stale claims,
+  understated compatibility or operational impact, and validation claims not
+  supported by the changed tests or available evidence. A missing or brief
+  description is not itself a defect; raise it only when it hides material
+  behavior, compatibility impact, or an unsupported claim.
+- Distinguish necessary supporting changes from unrelated cleanup. Do not
+  request a split merely because a coherent change spans many files or product
+  layers.
+- Put scope, description-alignment, split, and additional-review feedback only
+  in the top-level review summary, never on an arbitrary changed line.
+- Request an independent multi-model review sparingly, only for high-blast-
+  radius changes such as:
+  - Wire-level IPC contracts or serialization protocols shared with external
+    clients.
+  - Structural redesigns of core test-execution scheduling, synchronization,
+    cancellation, or `ExecutionContext` propagation.
+  - New process-launch, arbitrary-code-execution, privilege, or other security
+    boundaries.
+  - Cross-product changes with independent compatibility or rollback risks.
+- Do not request a multi-model review for routine public API additions, bug
+  fixes, analyzer changes, adapter features, or test-only changes. Put the
+  request in the review summary and name the exact failure mode, compatibility
+  concern, race, or attack surface the additional models should examine.
 
 ## Core TestFx checks
 
@@ -38,6 +80,9 @@ tests to understand the changed behavior before commenting.
 - New public API must be minimal, documented, MUST NOT use `init`, and be
   recorded in the relevant `PublicAPI.Unshipped.txt`. Also check internal API
   baselines in projects that track them.
+- Every API marked `[Experimental]` must include this sentence in its XML
+  documentation `<remarks>`: `This API is experimental. It may change, break,
+  or be removed at any time without notice.`
 - Check every target framework affected by the change. Do not assume an API
   available on modern .NET exists on older targets.
 - Review concurrency and lifecycle ordering carefully. Test execution is
@@ -46,11 +91,66 @@ tests to understand the changed behavior before commenting.
 - For shared or linked source, identify every consuming project and ensure API
   baselines and behavior remain consistent in all of them.
 - User-facing strings belong in resources. Never accept manually edited XLF
-  files; verify resource lock markers do not accidentally lock substrings.
+  files. Every `{Locked="..."}` token must occur verbatim in the corresponding
+  value; verify it does not accidentally lock a substring of a translatable
+  word.
 - CLI option changes must update the matching `--help` and `--info` acceptance
   expectations, including punctuation and alphabetical ordering.
 - Packable projects need valid package descriptions and `PACKAGE.md`.
+- Never accept manual changes under `eng/common/`; those files are mirrored
+  from `dotnet/arcade` and overwritten by automation.
+- Do not weaken `ApplicationStateGuard.Unreachable()`, `Debug.Assert`, or
+  explicit invariant throws into silent fallbacks, warnings, or empty returns
+  without a concrete external trigger or failing test that disproves the
+  invariant.
+- Workflow, script, issue-template, and policy changes must use native GitHub
+  Issue Types and must not introduce the deprecated `type/bug`, `type/feature`,
+  or `type/task` labels.
 - Do not allow untracked `TODO` comments.
+
+## Security checks
+
+Review changed trust boundaries for concrete security regressions. Pay particular
+attention when the change handles paths, process arguments, environment
+variables, protocol messages, serialized data, logs, artifacts, credentials,
+reflection, extensions, or arbitrary user test code.
+
+- Ensure untrusted file and directory names cannot escape the intended root
+  through traversal, rooted paths, alternate separators, or symlink behavior.
+- Ensure process launches preserve argument boundaries and do not concatenate
+  untrusted values into a command line, shell command, or executable path.
+  Check executable resolution, working-directory selection, inherited
+  environment variables, and assembly or plugin search paths.
+- Validate untrusted protocol and serialized input before using it, including
+  message type, required fields, payload and collection bounds, and unsupported
+  values. Reject unsafe polymorphic or binary deserialization of untrusted data.
+- Treat reflection, user callbacks, test methods, data sources, extensions, and
+  assembly discovery as hostile-code boundaries. Ensure exceptions are
+  contained appropriately, cancellation and timeouts remain enforceable, and
+  user-controlled input cannot cause unbounded memory or resource growth.
+- Do not expose secrets, tokens, environment values, private paths, or sensitive
+  test data through logs, exceptions, reports, artifacts, telemetry, or
+  temporary files.
+- Check that temporary files and artifacts use safe locations, appropriate
+  access, collision-resistant names, and reliable cleanup.
+- Treat workflow permission, network access, action pin, and secret-handling
+  changes as security boundaries; reject unnecessary privilege expansion or
+  mutable third-party references.
+- For dependency changes, check whether the new package or version introduces a
+  known vulnerability, unexpected runtime asset, or broader transitive surface.
+  Use authoritative evidence such as official advisories, NuGet metadata, and
+  upstream release notes; preserve uncertainty rather than guessing.
+
+Report a security finding only when the changed code creates a plausible attack
+or disclosure scenario with an observable consequence. Defensive coding belongs
+at actual external boundaries; do not request blanket hardening of trusted
+internal invariants without a concrete external trigger.
+
+For a suspected vulnerability or security-driven dependency update, do not put
+proofs of concept, attacker payloads, exploit steps, CVE details, affected
+version ranges, or other actionable vulnerability details in public review
+comments or PR metadata. Leave at most a minimal public note and follow
+`SECURITY.md` and the repository's private reporting process.
 
 ## Test changes
 
@@ -92,9 +192,11 @@ Apply these additional repository resources when their paths are changed:
 
 - MSBuild files (`*.props`, `*.targets`, `*.csproj`, SDK and NuGet build
   extensions): use the rule catalog in
-  `.github/agents/msbuild-reviewer.agent.md`. Use its review criteria only; the
-  GitHub code-review service owns posting comments.
-- Broad TestFx architecture, runtime, API, performance, and compatibility
+  `.github/agents/msbuild-reviewer.agent.md`. Ignore its operating modes,
+  finding cap, orchestration instructions, and output contract; the GitHub
+  code-review service owns review formatting and posting.
+- Broad TestFx architecture, runtime, API, performance, compatibility,
+  security-boundary, IPC, process-launch, serialization, and artifact-handling
   changes: use the applicable review dimensions in
   `.github/agents/expert-reviewer.agent.md`. Ignore workflow-specific posting,
   attribution, and safe-output instructions in that file.
@@ -110,7 +212,10 @@ Every finding must:
 
 - Identify a concrete scenario that triggers the problem.
 - Explain the observable consequence.
-- Point to a changed line.
+- Point to a changed line for code findings.
+- Put PR-level scope, description, split, and multi-model-review feedback in the
+  overall review summary and identify the specific unsupported claim,
+  unexplained change group, or high-risk boundary.
 - Recommend the smallest safe correction.
 - Use severity proportional to impact; do not elevate maintainability or style
   suggestions into correctness findings.


### PR DESCRIPTION
The TestFx review skill should evaluate more than line-level correctness: it should catch incoherent PR scope, misleading descriptions, security regressions, and high-risk changes that deserve additional independent scrutiny.

This update:

- adds evidence-based PR scope and description-alignment checks, with PR-level feedback restricted to the review summary;
- introduces concrete security checks for paths, process execution, deserialization, hostile test code, secrets, workflows, artifacts, and dependencies;
- adds missing TestFx invariants for experimental APIs, localization locks, `eng/common`, invariant guards, and native GitHub Issue Types;
- defines narrow, actionable triggers for requesting a multi-model review while excluding routine changes;
- clarifies how the skill consumes the MSBuild and expert reviewer guidance without inheriting their orchestration or output contracts.

The guidance was assessed independently by multiple models and refined where their findings converged. Markdown whitespace validation passes with `git diff --check`.