### PR TITLE
Preserve inner exceptions in server mode

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Microsoft.Testing.Platform.ServerMode.Client.Sources.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Microsoft.Testing.Platform.ServerMode.Client.Sources.csproj
@@ -119,6 +119,7 @@
     <Compile Include="$(MTPDir)ServerMode\JsonRpc\IObjectSerializer.cs" Link="Linked\ServerMode\JsonRpc\IObjectSerializer.cs" />
     <Compile Include="$(MTPDir)ServerMode\JsonRpc\IObjectDeserializer.cs" Link="Linked\ServerMode\JsonRpc\IObjectDeserializer.cs" />
     <Compile Include="$(MTPDir)ServerMode\JsonRpc\MessageFormatException.cs" Link="Linked\ServerMode\JsonRpc\MessageFormatException.cs" />
+    <Compile Include="$(MTPDir)OutputDevice\Terminal\ExceptionFlattener.cs" Link="Linked\OutputDevice\Terminal\ExceptionFlattener.cs" />
     <!-- Transport: the LSP-style framing engine, reused verbatim by the client. -->
     <Compile Include="$(MTPDir)ServerMode\JsonRpc\IMessageHandler.cs" Link="Linked\ServerMode\JsonRpc\IMessageHandler.cs" />
     <Compile Include="$(MTPDir)ServerMode\JsonRpc\TcpMessageHandler.cs" Link="Linked\ServerMode\JsonRpc\TcpMessageHandler.cs" />

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.Testing.Platform.ServerMode.ClientCapabilities.ClientCapabilities(bool
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.Deconstruct(out bool DebuggerProvider, out bool? IsStateful) -> void
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool?
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.init -> void
+static Microsoft.Testing.Platform.ServerMode.SerializerUtilities.FormatException(string? explanation, System.Exception? exception) -> (string? Message, string? StackTrace)
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool? DeclaredIsStateful) -> void
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool? DeclaredIsStateful) -> void
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.DeclaredIsStateful.get -> bool?

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.TestNodeSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.TestNodeSerializer.cs
@@ -129,10 +129,13 @@ internal sealed partial class Json
                         {
                             properties.Add(("execution-state", "failed"));
                             Exception? exception = failedTestNodeStateProperty.Exception;
-                            properties.Add(("error.message", failedTestNodeStateProperty.Explanation ?? exception?.Message));
-                            if (exception is not null)
+                            (string? errorMessage, string? errorStackTrace) = SerializerUtilities.FormatException(
+                                failedTestNodeStateProperty.Explanation,
+                                exception);
+                            properties.Add(("error.message", errorMessage));
+                            if (errorStackTrace is not null)
                             {
-                                properties.Add(("error.stacktrace", exception.StackTrace ?? string.Empty));
+                                properties.Add(("error.stacktrace", errorStackTrace));
                             }
 
                             // AssertionFailureProperty is the supported channel; Exception.Data is the legacy
@@ -155,11 +158,13 @@ internal sealed partial class Json
                     case TimeoutTestNodeStateProperty timeoutTestNodeStateProperty:
                         {
                             properties.Add(("execution-state", "timed-out"));
-                            Exception? exception = timeoutTestNodeStateProperty.Exception;
-                            properties.Add(("error.message", timeoutTestNodeStateProperty.Explanation ?? exception?.Message));
-                            if (exception is not null)
+                            (string? errorMessage, string? errorStackTrace) = SerializerUtilities.FormatException(
+                                timeoutTestNodeStateProperty.Explanation,
+                                timeoutTestNodeStateProperty.Exception);
+                            properties.Add(("error.message", errorMessage));
+                            if (errorStackTrace is not null)
                             {
-                                properties.Add(("error.stacktrace", exception.StackTrace ?? string.Empty));
+                                properties.Add(("error.stacktrace", errorStackTrace));
                             }
 
                             break;
@@ -168,11 +173,13 @@ internal sealed partial class Json
                     case ErrorTestNodeStateProperty errorTestNodeStateProperty:
                         {
                             properties.Add(("execution-state", "error"));
-                            Exception? exception = errorTestNodeStateProperty.Exception;
-                            properties.Add(("error.message", errorTestNodeStateProperty.Explanation ?? exception?.Message));
-                            if (exception is not null)
+                            (string? errorMessage, string? errorStackTrace) = SerializerUtilities.FormatException(
+                                errorTestNodeStateProperty.Explanation,
+                                errorTestNodeStateProperty.Exception);
+                            properties.Add(("error.message", errorMessage));
+                            if (errorStackTrace is not null)
                             {
-                                properties.Add(("error.stacktrace", exception.StackTrace ?? string.Empty));
+                                properties.Add(("error.stacktrace", errorStackTrace));
                             }
 
                             break;
@@ -183,11 +190,13 @@ internal sealed partial class Json
 #pragma warning restore CS0618, MTP0001 // Type or member is obsolete
                         {
                             properties.Add(("execution-state", "canceled"));
-                            Exception? exception = canceledTestNodeStateProperty.Exception;
-                            properties.Add(("error.message", canceledTestNodeStateProperty.Explanation ?? exception?.Message));
-                            if (exception is not null)
+                            (string? errorMessage, string? errorStackTrace) = SerializerUtilities.FormatException(
+                                canceledTestNodeStateProperty.Explanation,
+                                canceledTestNodeStateProperty.Exception);
+                            properties.Add(("error.message", errorMessage));
+                            if (errorStackTrace is not null)
                             {
-                                properties.Add(("error.stacktrace", exception.StackTrace ?? string.Empty));
+                                properties.Add(("error.stacktrace", errorStackTrace));
                             }
 
                             break;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
@@ -7,6 +7,7 @@
 using Jsonite;
 #endif
 using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.OutputDevice.Terminal;
 
 namespace Microsoft.Testing.Platform.ServerMode;
 
@@ -188,11 +189,14 @@ internal static partial class SerializerUtilities
                             case FailedTestNodeStateProperty failedTestNodeStateProperty:
                                 {
                                     properties["execution-state"] = "failed";
-                                    properties["error.message"] = failedTestNodeStateProperty.Explanation ?? failedTestNodeStateProperty.Exception?.Message;
                                     Exception? exception = failedTestNodeStateProperty.Exception;
-                                    if (exception is not null)
+                                    (string? errorMessage, string? errorStackTrace) = FormatException(
+                                        failedTestNodeStateProperty.Explanation,
+                                        exception);
+                                    properties["error.message"] = errorMessage;
+                                    if (errorStackTrace is not null)
                                     {
-                                        properties["error.stacktrace"] = exception.StackTrace ?? string.Empty;
+                                        properties["error.stacktrace"] = errorStackTrace;
                                     }
 
                                     // AssertionFailureProperty is the supported channel; Exception.Data is the
@@ -215,10 +219,13 @@ internal static partial class SerializerUtilities
                             case TimeoutTestNodeStateProperty timeoutTestNodeStateProperty:
                                 {
                                     properties["execution-state"] = "timed-out";
-                                    properties["error.message"] = timeoutTestNodeStateProperty.Explanation ?? timeoutTestNodeStateProperty.Exception?.Message;
-                                    if (timeoutTestNodeStateProperty.Exception is not null)
+                                    (string? errorMessage, string? errorStackTrace) = FormatException(
+                                        timeoutTestNodeStateProperty.Explanation,
+                                        timeoutTestNodeStateProperty.Exception);
+                                    properties["error.message"] = errorMessage;
+                                    if (errorStackTrace is not null)
                                     {
-                                        properties["error.stacktrace"] = timeoutTestNodeStateProperty.Exception.StackTrace ?? string.Empty;
+                                        properties["error.stacktrace"] = errorStackTrace;
                                     }
 
                                     break;
@@ -227,10 +234,13 @@ internal static partial class SerializerUtilities
                             case ErrorTestNodeStateProperty errorTestNodeStateProperty:
                                 {
                                     properties["execution-state"] = "error";
-                                    properties["error.message"] = errorTestNodeStateProperty.Explanation ?? errorTestNodeStateProperty.Exception?.Message;
-                                    if (errorTestNodeStateProperty.Exception is not null)
+                                    (string? errorMessage, string? errorStackTrace) = FormatException(
+                                        errorTestNodeStateProperty.Explanation,
+                                        errorTestNodeStateProperty.Exception);
+                                    properties["error.message"] = errorMessage;
+                                    if (errorStackTrace is not null)
                                     {
-                                        properties["error.stacktrace"] = errorTestNodeStateProperty.Exception.StackTrace ?? string.Empty;
+                                        properties["error.stacktrace"] = errorStackTrace;
                                     }
 
                                     break;
@@ -241,10 +251,13 @@ internal static partial class SerializerUtilities
 #pragma warning restore CS0618, MTP0001 // Type or member is obsolete
                                 {
                                     properties["execution-state"] = "canceled";
-                                    properties["error.message"] = canceledTestNodeStateProperty.Explanation ?? canceledTestNodeStateProperty.Exception?.Message;
-                                    if (canceledTestNodeStateProperty.Exception is not null)
+                                    (string? errorMessage, string? errorStackTrace) = FormatException(
+                                        canceledTestNodeStateProperty.Explanation,
+                                        canceledTestNodeStateProperty.Exception);
+                                    properties["error.message"] = errorMessage;
+                                    if (errorStackTrace is not null)
                                     {
-                                        properties["error.stacktrace"] = canceledTestNodeStateProperty.Exception.StackTrace ?? string.Empty;
+                                        properties["error.stacktrace"] = errorStackTrace;
                                     }
 
                                     break;
@@ -300,5 +313,52 @@ internal static partial class SerializerUtilities
 
                 return properties;
             });
+    }
+
+    internal static (string? Message, string? StackTrace) FormatException(string? explanation, Exception? exception)
+    {
+        if (exception is null)
+        {
+            return (explanation, null);
+        }
+
+        FlatException[] exceptions = ExceptionFlattener.Flatten(null, exception);
+        if (exceptions.Length == 1)
+        {
+            return (explanation ?? exception.Message, exception.StackTrace ?? string.Empty);
+        }
+
+        StringBuilder message = new(explanation ?? exception.Message);
+        StringBuilder stackTrace = new(exception.StackTrace ?? string.Empty);
+        for (int i = 1; i < exceptions.Length; i++)
+        {
+            FlatException innerException = exceptions[i];
+            if (message.Length > 0)
+            {
+                message.AppendLine();
+            }
+
+            message
+                .Append(" ---> ")
+                .Append(innerException.ErrorType)
+                .Append(": ")
+                .Append(innerException.ErrorMessage);
+
+            if (!RoslynString.IsNullOrEmpty(innerException.StackTrace))
+            {
+                if (stackTrace.Length > 0)
+                {
+                    stackTrace.AppendLine();
+                }
+
+                stackTrace
+                    .Append("--- Inner exception stack trace (")
+                    .Append(innerException.ErrorType)
+                    .AppendLine(") ---")
+                    .Append(innerException.StackTrace);
+            }
+        }
+
+        return (message.ToString(), stackTrace.ToString());
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -559,6 +559,69 @@ public sealed class FormatterUtilitiesTests
         Assert.DoesNotContain("legacy", serialized);
     }
 
+    [TestMethod]
+    public async Task Serialize_ExceptionStates_IncludeInnerExceptionMessagesAndStackTraces()
+    {
+        var innerException = new FixedStackTraceException("inner", "inner-stack");
+        var exception = new FixedStackTraceException("outer", "outer-stack", innerException);
+        string expectedMessage = $"explanation{Environment.NewLine} ---> {typeof(FixedStackTraceException).FullName}: inner";
+        string expectedStackTrace = $"outer-stack{Environment.NewLine}--- Inner exception stack trace ({typeof(FixedStackTraceException).FullName}) ---{Environment.NewLine}inner-stack";
+
+#pragma warning disable CS0618, MTP0001 // Type or member is obsolete
+        (TestNodeStateProperty State, string ExecutionState)[] states =
+        [
+            (new FailedTestNodeStateProperty(exception, "explanation"), "failed"),
+            (new ErrorTestNodeStateProperty(exception, "explanation"), "error"),
+            (new TimeoutTestNodeStateProperty(exception, "explanation"), "timed-out"),
+            (new CancelledTestNodeStateProperty(exception, "explanation"), "canceled"),
+        ];
+#pragma warning restore CS0618, MTP0001 // Type or member is obsolete
+
+        foreach ((TestNodeStateProperty state, string executionState) in states)
+        {
+            var testNode = new TestNode
+            {
+                Uid = $"test-{executionState}",
+                DisplayName = $"Test {executionState}",
+                Properties = new PropertyBag(state),
+            };
+
+            IDictionary<string, object?> properties = SerializerUtilities.Serialize(testNode);
+            string serialized = await _formatter.SerializeAsync(testNode);
+
+            Assert.AreEqual(expectedMessage, properties["error.message"]);
+            Assert.AreEqual(expectedStackTrace, properties["error.stacktrace"]);
+            Assert.Contains(EscapeJsonString(expectedMessage), serialized);
+            Assert.Contains(EscapeJsonString(expectedStackTrace), serialized);
+        }
+    }
+
+    [TestMethod]
+    public void FormatException_AggregateException_IncludesEveryBranch()
+    {
+        var firstException = new FixedStackTraceException("first", "first-stack");
+        var secondException = new FixedStackTraceException("second", "second-stack");
+        var aggregateException = new AggregateException("aggregate", firstException, secondException);
+
+        (string? message, string? stackTrace) = SerializerUtilities.FormatException(null, aggregateException);
+
+        Assert.AreEqual(
+            string.Join(
+                Environment.NewLine,
+                aggregateException.Message,
+                $" ---> {typeof(FixedStackTraceException).FullName}: first",
+                $" ---> {typeof(FixedStackTraceException).FullName}: second"),
+            message);
+        Assert.AreEqual(
+            string.Join(
+                Environment.NewLine,
+                $"--- Inner exception stack trace ({typeof(FixedStackTraceException).FullName}) ---",
+                "first-stack",
+                $"--- Inner exception stack trace ({typeof(FixedStackTraceException).FullName}) ---",
+                "second-stack"),
+            stackTrace);
+    }
+
     [DataRow(typeof(DiscoverRequestArgs))]
     [DataRow(typeof(RunRequestArgs))]
     [TestMethod]
@@ -1049,4 +1112,32 @@ public sealed class FormatterUtilitiesTests
             _ when type == typeof(ServerCapabilities) => Deserialize<ServerCapabilities>(instanceSerialized)!,
             _ => throw new NotImplementedException($"Deserializer for type not implemented '{type}'"),
         };
+
+    private static string EscapeJsonString(string value)
+    {
+        string escapedValue = value
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"")
+            .Replace("\r", "\\r")
+            .Replace("\n", "\\n");
+
+#if NETCOREAPP
+        escapedValue = escapedValue
+            .Replace("+", "\\u002B")
+            .Replace(">", "\\u003E");
+#endif
+
+        return escapedValue;
+    }
+
+    private sealed class FixedStackTraceException : Exception
+    {
+        private readonly string _stackTrace;
+
+        public FixedStackTraceException(string message, string stackTrace, Exception? innerException = null)
+            : base(message, innerException)
+            => _stackTrace = stackTrace;
+
+        public override string StackTrace => _stackTrace;
+    }
 }


### PR DESCRIPTION
Server-mode JSON-RPC currently sends only the outer exception message and stack trace, so IDE clients lose the underlying failure details that terminal and `dotnet test` output already preserve.

This change keeps the existing protocol shape while flattening exception details into `error.message` and `error.stacktrace` for failed, error, timed-out, and canceled test nodes. Both the System.Text.Json and Jsonite serializers use the same formatting helper, backed by the existing `ExceptionFlattener`. The source-only server client package now includes that shared helper as well.

Tests cover nested exceptions across all affected states and multi-branch `AggregateException` output on both serializer implementations.

Validation:
- `Microsoft.Testing.Platform.UnitTests` `FormatterUtilitiesTests`: 84/84 passed on net8.0
- `Microsoft.Testing.Platform.UnitTests` `FormatterUtilitiesTests`: 84/84 passed on net462
- `Microsoft.Testing.Platform.ServerMode.Client.Sources` builds successfully

Fixes: #11202