### PR TITLE
Reorder analyzer structural checks before framework lookup

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/InheritedMemberFromDifferentMSTestVersionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/InheritedMemberFromDifferentMSTestVersionAnalyzer.cs
@@ -88,21 +88,18 @@ public sealed class InheritedMemberFromDifferentMSTestVersionAnalyzer : Diagnost
         // constructed without the container's type arguments — and the type must be visible enough to be discovered
         // (public, or internal when the assembly opts into DiscoverInternals). Concrete, accessible, non-generic derived
         // classes are analyzed separately and still get the warning.
-        // These structural checks are cheap (no attribute enumeration or reference-list scan) and reject the vast
-        // majority of named-type symbols in a typical compilation (interfaces, structs, enums, abstract/generic/
-        // non-discoverable classes), so they run first to avoid the more expensive GetFrameworkAssembly lookup below
-        // for symbols that would be filtered out anyway.
+        // These type-only checks are cheap and reject the majority of named-type symbols in a typical compilation, so
+        // they run first to avoid the more expensive GetFrameworkAssembly lookup for symbols filtered out anyway.
         if (classSymbol.IsAbstract
             || classSymbol.IsGenericType
             || IsNestedInGenericType(classSymbol)
-            || !IsDiscoverableTestClassVisibility(classSymbol, canDiscoverInternals)
-            || !classSymbol.HasCorrectTestContextSignature())
+            || !IsDiscoverableTestClassVisibility(classSymbol, canDiscoverInternals))
         {
             return;
         }
 
         IAssemblySymbol? referenceAssembly = GetFrameworkAssembly(context.Compilation, classSymbol);
-        if (referenceAssembly is null)
+        if (referenceAssembly is null || !classSymbol.HasCorrectTestContextSignature())
         {
             return;
         }

--- a/src/Analyzers/MSTest.Analyzers/InheritedMemberFromDifferentMSTestVersionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/InheritedMemberFromDifferentMSTestVersionAnalyzer.cs
@@ -82,19 +82,27 @@ public sealed class InheritedMemberFromDifferentMSTestVersionAnalyzer : Diagnost
     private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol? taskSymbol, INamedTypeSymbol? valueTaskSymbol, bool canDiscoverInternals)
     {
         var classSymbol = (INamedTypeSymbol)context.Symbol;
-        IAssemblySymbol? referenceAssembly = GetFrameworkAssembly(context.Compilation, classSymbol);
 
         // A test class the adapter cannot discover never runs, so no inherited member can run for it: abstract and
         // generic types are rejected — including a concrete class nested in a generic container, which cannot be
         // constructed without the container's type arguments — and the type must be visible enough to be discovered
         // (public, or internal when the assembly opts into DiscoverInternals). Concrete, accessible, non-generic derived
         // classes are analyzed separately and still get the warning.
-        if (referenceAssembly is null
-            || classSymbol.IsAbstract
+        // These structural checks are cheap (no attribute enumeration or reference-list scan) and reject the vast
+        // majority of named-type symbols in a typical compilation (interfaces, structs, enums, abstract/generic/
+        // non-discoverable classes), so they run first to avoid the more expensive GetFrameworkAssembly lookup below
+        // for symbols that would be filtered out anyway.
+        if (classSymbol.IsAbstract
             || classSymbol.IsGenericType
             || IsNestedInGenericType(classSymbol)
             || !IsDiscoverableTestClassVisibility(classSymbol, canDiscoverInternals)
             || !classSymbol.HasCorrectTestContextSignature())
+        {
+            return;
+        }
+
+        IAssemblySymbol? referenceAssembly = GetFrameworkAssembly(context.Compilation, classSymbol);
+        if (referenceAssembly is null)
         {
             return;
         }


### PR DESCRIPTION
`InheritedMemberFromDifferentMSTestVersionAnalyzer` currently performs attribute enumeration and scans compilation references for every named type before rejecting types that cannot be discovered as tests.

Move the cheap abstract, generic, nesting, visibility, and `TestContext` signature checks ahead of `GetFrameworkAssembly`. This preserves analyzer behavior while avoiding the expensive lookup for the majority of named types in a typical compilation.

Validation: built `MSTest.Analyzers.UnitTests` and ran all 67 `InheritedMemberFromDifferentMSTestVersionAnalyzerTests` on `net8.0` successfully.

Closes #11222